### PR TITLE
LEST-26 - Implemented more equality matchers

### DIFF
--- a/src/matchers/equality.lua
+++ b/src/matchers/equality.lua
@@ -51,13 +51,41 @@ local function toEqual(ctx, received, expected)
 end
 
 ---@type lest.Matcher
-local function toBeTruthy(ctx, received) end
+local function toBeTruthy(ctx, received)
+	return {
+		pass = not not received,
+		message = string.format(
+			"Expected %s to%sbe truthy",
+			prettyValue(received),
+			ctx.inverted and " not " or " "
+		),
+	}
+end
 
 ---@type lest.Matcher
-local function toBeFalsy(ctx, received) end
+local function toBeFalsy(ctx, received)
+	return {
+		pass = not received,
+		message = string.format(
+			"Expected %s to%sbe falsy",
+			prettyValue(received),
+			ctx.inverted and " not " or " "
+		),
+	}
+end
 
 ---@type lest.Matcher
-local function toBeInstanceOf(ctx, received, metatable) end
+local function toBeInstanceOf(ctx, received, metatable)
+	return {
+		pass = deepEqual(getmetatable(received), metatable),
+		message = string.format(
+			"Expected %s to%sbe an instance of %s",
+			prettyValue(received),
+			ctx.inverted and " not " or " ",
+			prettyValue(metatable)
+		),
+	}
+end
 
 return {
 	toBe = toBe,
@@ -65,6 +93,11 @@ return {
 	toBeDefined = toBeDefined,
 	toBeUndefined = toBeUndefined,
 	toBeNil = toBeUndefined,
+
+	toBeTruthy = toBeTruthy,
+	toBeFalsy = toBeFalsy,
+
+	toBeInstanceOf = toBeInstanceOf,
 
 	toEqual = toEqual,
 }

--- a/src/matchers/equality.lua
+++ b/src/matchers/equality.lua
@@ -76,8 +76,10 @@ end
 
 ---@type lest.Matcher
 local function toBeInstanceOf(ctx, received, metatable)
+	assert(type(metatable) == "table", "Metatable must be a table")
+
 	return {
-		pass = deepEqual(getmetatable(received), metatable),
+		pass = getmetatable(received) == metatable,
 		message = string.format(
 			"Expected %s to%sbe an instance of %s",
 			prettyValue(received),

--- a/src/matchers/equality.test.lua
+++ b/src/matchers/equality.test.lua
@@ -1,0 +1,141 @@
+-- This test suite doesn't rely on the equality matchers since they're being tested. Instead this suite uses
+-- basic lua assertions to verify matcher behavior.
+
+local function matcherPassed(fn)
+	local passed = pcall(fn)
+	return passed
+end
+
+describe("equality matchers", function()
+	describe("toBe", function()
+		it("should pass on equality", function()
+			assert(matcherPassed(function()
+				expect(2).toBe(2)
+			end))
+		end)
+
+		it("shouldn't pass on inequality", function()
+			assert(not matcherPassed(function()
+				expect(2).toBe(4)
+			end))
+		end)
+	end)
+
+	describe("toBeDefined", function()
+		it("should pass when defined", function()
+			assert(matcherPassed(function()
+				expect(20).toBeDefined()
+			end))
+		end)
+
+		it("shouldn't pass when undefined", function()
+			assert(not matcherPassed(function()
+				expect(nil).toBeDefined()
+			end))
+		end)
+	end)
+
+	describe("toBeUndefined", function()
+		it("should pass when undefined", function()
+			assert(matcherPassed(function()
+				expect(nil).toBeUndefined()
+			end))
+		end)
+
+		it("shouldn't pass when defined", function()
+			assert(not matcherPassed(function()
+				expect(23).toBeUndefined()
+			end))
+		end)
+	end)
+
+	describe("toEqual", function()
+		it("should pass on equality", function()
+			assert(matcherPassed(function()
+				expect(10).toEqual(10)
+			end))
+		end)
+
+		it("shouldn't error on inequality", function()
+			assert(not matcherPassed(function()
+				expect(40).toEqual(20)
+			end))
+		end)
+
+		it("should pass on deep equality", function()
+			assert(matcherPassed(function()
+				local testTableOne = { a = 2, ["kruger"] = 11 }
+				local testTableTwo = { a = 2, ["kruger"] = 11 }
+
+				expect(testTableOne).toEqual(testTableTwo)
+			end))
+		end)
+
+		it("shouldn't pass on deep inequality", function()
+			assert(not matcherPassed(function()
+				local testTableOne = { 1337, a = 2, ["kruger"] = 11 }
+				local testTableTwo = { a = 2, ["kruger"] = 11 }
+
+				expect(testTableOne).toEqual(testTableTwo)
+			end))
+		end)
+	end)
+
+	describe("toBeTruthy", function()
+		it("should pass on truthy values", function()
+			assert(matcherPassed(function()
+				expect(true).toBeTruthy()
+				-- FYI: 1 and 0 are both truthy in Lua unlike other languages.
+				expect(1).toBeTruthy()
+				expect(0).toBeTruthy()
+				expect("").toBeTruthy()
+			end))
+		end)
+
+		it("shouldn't pass on falsy values", function()
+			assert(not matcherPassed(function()
+				expect(nil).toBeTruthy()
+				expect(false).toBeTruthy()
+			end))
+		end)
+	end)
+
+	describe("toBeFalsy", function()
+		it("should pass on falsy values", function()
+			assert(matcherPassed(function()
+				expect(nil).toBeFalsy()
+				expect(false).toBeFalsy()
+			end))
+		end)
+
+		it("shouldn't pass on truthy values", function()
+			assert(not matcherPassed(function()
+				expect(true).toBeFalsy()
+				expect(1).toBeFalsy()
+				expect(0).toBeFalsy()
+				expect("").toBeFalsy()
+			end))
+		end)
+	end)
+
+	describe("toBeInstanceOf", function()
+		local TestClass = {}
+		TestClass.__index = TestClass
+
+		function TestClass.new()
+			return setmetatable({ randomMember = 2 }, TestClass)
+		end
+
+		it("should pass on instances of a class", function()
+			assert(matcherPassed(function()
+				expect(TestClass.new()).toBeInstanceOf(TestClass)
+			end))
+		end)
+
+		it("shouldn't pass on non-instances of a class", function()
+			assert(not matcherPassed(function()
+				expect({}).toBeInstanceOf(TestClass)
+			end))
+		end)
+	end)
+end)

--- a/src/matchers/equality.test.lua
+++ b/src/matchers/equality.test.lua
@@ -1,141 +1,371 @@
--- This test suite doesn't rely on the equality matchers since they're being tested. Instead this suite uses
--- basic lua assertions to verify matcher behavior.
+local equality = require("src.matchers.equality")
 
-local function matcherPassed(fn)
-	local passed = pcall(fn)
-	return passed
+--- Asserts that a matcher passed
+---@param result lest.TestResult Result of the matcher
+local function assertPass(result)
+	assert(result.pass, "test failed when it should have passed!")
 end
+
+--- Asserts that a matcher failed
+---@param result lest.TestResult Result of the matcher
+---@param expectedMsg string Expected message of the matcher
+local function assertFail(result, expectedMsg)
+	assert(result.message == expectedMsg, "test has an incorrect fail message!")
+end
+
+local CONTEXT = {
+	inverted = false,
+}
+
+local INVERTED_CONTEXT = {
+	inverted = true,
+}
 
 describe("equality matchers", function()
 	describe("toBe", function()
-		it("should pass on equality", function()
-			assert(matcherPassed(function()
-				expect(2).toBe(2)
-			end))
+		it("should pass when the arguments are equal", function()
+			local result = equality.toBe(CONTEXT, 2, 2)
+
+			assertPass(result)
 		end)
 
-		it("shouldn't pass on inequality", function()
-			assert(not matcherPassed(function()
-				expect(2).toBe(4)
-			end))
+		it("should fail when the arguments aren't equal", function()
+			local result = equality.toBe(CONTEXT, 2, 42)
+
+			assertFail(result, "Expected 2 to be 42")
+		end)
+
+		it(
+			"should pass when inverted and the arguments aren't equal",
+			function()
+				local result = equality.toBe(INVERTED_CONTEXT, 2, 42)
+				result.pass = not result.pass
+
+				assertPass(result)
+			end
+		)
+
+		it("should fail when inverted and the arguments are equal", function()
+			local result = equality.toBe(INVERTED_CONTEXT, 2, 2)
+			result.pass = not result.pass
+
+			assertFail(result, "Expected 2 to not be 2")
 		end)
 	end)
 
 	describe("toBeDefined", function()
 		it("should pass when defined", function()
-			assert(matcherPassed(function()
-				expect(20).toBeDefined()
-			end))
+			local result = equality.toBeDefined(CONTEXT, 10)
+
+			assertPass(result)
 		end)
 
-		it("shouldn't pass when undefined", function()
-			assert(not matcherPassed(function()
-				expect(nil).toBeDefined()
-			end))
+		it("should fail when undefined", function()
+			local result = equality.toBeDefined(CONTEXT, nil)
+
+			assertFail(result, "Expected nil to be defined")
+		end)
+
+		it("should pass when inverted and undefined", function()
+			local result = equality.toBeDefined(INVERTED_CONTEXT, nil)
+			result.pass = not result.pass
+
+			assertPass(result)
+		end)
+
+		it("should fail when inverted and defined", function()
+			local result = equality.toBeDefined(INVERTED_CONTEXT, 10)
+			result.pass = not result.pass
+
+			assertFail(result, "Expected 10 to be undefined")
 		end)
 	end)
 
 	describe("toBeUndefined", function()
 		it("should pass when undefined", function()
-			assert(matcherPassed(function()
-				expect(nil).toBeUndefined()
-			end))
+			local result = equality.toBeUndefined(CONTEXT, nil)
+
+			assertPass(result)
 		end)
 
-		it("shouldn't pass when defined", function()
-			assert(not matcherPassed(function()
-				expect(23).toBeUndefined()
-			end))
+		it("should fail when defined", function()
+			local result = equality.toBeUndefined(CONTEXT, 10)
+
+			assertFail(result, "Expected 10 to be undefined")
+		end)
+
+		it("should pass when inverted and defined", function()
+			local result = equality.toBeUndefined(INVERTED_CONTEXT, 10)
+			result.pass = not result.pass
+
+			assertPass(result)
+		end)
+
+		it("should fail when inverted and undefined", function()
+			local result = equality.toBeUndefined(INVERTED_CONTEXT, nil)
+			result.pass = not result.pass
+
+			assertFail(result, "Expected nil to be defined")
 		end)
 	end)
 
 	describe("toEqual", function()
 		it("should pass on equality", function()
-			assert(matcherPassed(function()
-				expect(10).toEqual(10)
-			end))
+			local result = equality.toEqual(CONTEXT, 10, 10)
+
+			assertPass(result)
 		end)
 
-		it("shouldn't error on inequality", function()
-			assert(not matcherPassed(function()
-				expect(40).toEqual(20)
-			end))
+		it("should fail on inequality", function()
+			local result = equality.toEqual(CONTEXT, 10, 15)
+
+			assertFail(result, "Expected 10 to deeply equal 15")
 		end)
 
 		it("should pass on deep equality", function()
-			assert(matcherPassed(function()
-				local testTableOne = { a = 2, ["kruger"] = 11 }
-				local testTableTwo = { a = 2, ["kruger"] = 11 }
+			local tableOne = {
+				hi = 10,
+				["turing"] = "alan",
+				{
+					12,
+					14,
+					18,
+				},
+			}
 
-				expect(testTableOne).toEqual(testTableTwo)
-			end))
+			local tableTwo = {
+				hi = 10,
+				["turing"] = "alan",
+				{
+					12,
+					14,
+					18,
+				},
+			}
+
+			local result = equality.toEqual(CONTEXT, tableOne, tableTwo)
+
+			assertPass(result)
 		end)
 
-		it("shouldn't pass on deep inequality", function()
-			assert(not matcherPassed(function()
-				local testTableOne = { 1337, a = 2, ["kruger"] = 11 }
-				local testTableTwo = { a = 2, ["kruger"] = 11 }
+		it("should fail on deep inequality", function()
+			local tableOne = {
+				hi = 10,
+				["turing"] = "alan",
+				{
+					12,
+					14,
+					18,
+				},
+			}
 
-				expect(testTableOne).toEqual(testTableTwo)
-			end))
+			local tableTwo = {
+				hi = 10,
+				["turing"] = "alan",
+				{
+					12,
+					14,
+					18,
+					"I'm not supposed to be here",
+				},
+			}
+
+			local result = equality.toEqual(CONTEXT, tableOne, tableTwo)
+
+			assertFail(
+				result,
+				("Expected %s to deeply equal %s"):format(tableOne, tableTwo)
+			)
+		end)
+
+		it("should pass when inverted on inequality", function()
+			local result = equality.toEqual(INVERTED_CONTEXT, 5, 10)
+			result.pass = not result.pass
+
+			assertPass(result)
+		end)
+
+		it("should fail when inverted on equality", function()
+			local result = equality.toEqual(INVERTED_CONTEXT, 10, 10)
+
+			assertFail(result, "Expected 10 to not deeply equal 10")
+		end)
+
+		it("should pass when inverted on deep inequality", function()
+			local tableOne = {
+				hi = 10,
+				["turing"] = "alan",
+				{
+					12,
+					14,
+					18,
+				},
+			}
+
+			local tableTwo = {
+				hi = 10,
+				["turing"] = "alan",
+				{
+					12,
+					14,
+					18,
+					"I'm not supposed to be here",
+				},
+			}
+
+			local result =
+				equality.toEqual(INVERTED_CONTEXT, tableOne, tableTwo)
+			result.pass = not result.pass
+
+			assertPass(result)
+		end)
+
+		it("should fail when inverted on deep equality", function()
+			local tableOne = {
+				hi = 10,
+				["turing"] = "alan",
+				{
+					12,
+					14,
+					18,
+				},
+			}
+
+			local tableTwo = {
+				hi = 10,
+				["turing"] = "alan",
+				{
+					12,
+					14,
+					18,
+				},
+			}
+
+			local result =
+				equality.toEqual(INVERTED_CONTEXT, tableOne, tableTwo)
+
+			assertFail(
+				result,
+				("Expected %s to not deeply equal %s"):format(
+					tableOne,
+					tableTwo
+				)
+			)
 		end)
 	end)
 
 	describe("toBeTruthy", function()
 		it("should pass on truthy values", function()
-			assert(matcherPassed(function()
-				expect(true).toBeTruthy()
-				-- FYI: 1 and 0 are both truthy in Lua unlike other languages.
-				expect(1).toBeTruthy()
-				expect(0).toBeTruthy()
-				expect("").toBeTruthy()
-			end))
+			assertPass(equality.toBeTruthy(CONTEXT, true))
 		end)
 
-		it("shouldn't pass on falsy values", function()
-			assert(not matcherPassed(function()
-				expect(nil).toBeTruthy()
-				expect(false).toBeTruthy()
-			end))
+		it("should fail on falsy values", function()
+			assertFail(
+				equality.toBeTruthy(CONTEXT, false),
+				"Expected false to be truthy"
+			)
+			assertFail(
+				equality.toBeTruthy(CONTEXT, nil),
+				"Expected nil to be truthy"
+			)
+		end)
+
+		it("should fail when inverted on truthy values", function()
+			local result = equality.toBeTruthy(INVERTED_CONTEXT, true)
+			result.pass = not result.pass
+
+			assertFail(result, "Expected true to not be truthy")
+		end)
+
+		it("should pass when inverted on falsy values", function()
+			local result = equality.toBeTruthy(INVERTED_CONTEXT, false)
+			result.pass = not result.pass
+
+			assertPass(result)
+
+			result = equality.toBeTruthy(INVERTED_CONTEXT, nil)
+			result.pass = not result.pass
+
+			assertPass(result)
 		end)
 	end)
 
 	describe("toBeFalsy", function()
-		it("should pass on falsy values", function()
-			assert(matcherPassed(function()
-				expect(nil).toBeFalsy()
-				expect(false).toBeFalsy()
-			end))
+		it("should fail on truthy values", function()
+			assertFail(
+				equality.toBeFalsy(CONTEXT, true),
+				"Expected true to be falsy"
+			)
 		end)
 
-		it("shouldn't pass on truthy values", function()
-			assert(not matcherPassed(function()
-				expect(true).toBeFalsy()
-				expect(1).toBeFalsy()
-				expect(0).toBeFalsy()
-				expect("").toBeFalsy()
-			end))
+		it("should pass on falsy values", function()
+			assertPass(equality.toBeFalsy(CONTEXT, false))
+			assertPass(equality.toBeFalsy(CONTEXT, nil))
+		end)
+
+		it("should pass when inverted on truthy values", function()
+			local result = equality.toBeFalsy(INVERTED_CONTEXT, true)
+			result.pass = not result.pass
+
+			assertPass(result)
+		end)
+
+		it("should fail when inverted on falsy values", function()
+			local result = equality.toBeFalsy(INVERTED_CONTEXT, false)
+			result.pass = not result.pass
+
+			assertFail(result, "Expected false to not be falsy")
+
+			result = equality.toBeFalsy(INVERTED_CONTEXT, nil)
+			result.pass = not result.pass
+
+			assertFail(result, "Expected nil to not be falsy")
 		end)
 	end)
 
 	describe("toBeInstanceOf", function()
 		local TestClass = {}
-		TestClass.__index = TestClass
-
-		function TestClass.new()
-			return setmetatable({ randomMember = 2 }, TestClass)
-		end
+		local instance = setmetatable({}, TestClass)
 
 		it("should pass on instances of a class", function()
-			assert(matcherPassed(function()
-				expect(TestClass.new()).toBeInstanceOf(TestClass)
-			end))
+			assertPass(equality.toBeInstanceOf(CONTEXT, instance, TestClass))
 		end)
 
-		it("shouldn't pass on non-instances of a class", function()
-			assert(not matcherPassed(function()
-				expect({}).toBeInstanceOf(TestClass)
-			end))
+		it("should fail on non-instances of a class", function()
+			local nonInstance = {}
+			assertFail(
+				equality.toBeInstanceOf(CONTEXT, nonInstance, TestClass),
+				("Expected %s to be an instance of %s"):format(
+					nonInstance,
+					TestClass
+				)
+			)
+		end)
+
+		it("should fail when inverted on instances of a class", function()
+			local result =
+				equality.toBeInstanceOf(INVERTED_CONTEXT, instance, TestClass)
+			result.pass = not result.pass
+			assertFail(
+				result,
+				("Expected %s to not be an instance of %s"):format(
+					instance,
+					TestClass
+				)
+			)
+		end)
+
+		it("should pass when inverted on non-instances of a class", function()
+			local nonInstance = {}
+			local result = equality.toBeInstanceOf(
+				INVERTED_CONTEXT,
+				nonInstance,
+				TestClass
+			)
+
+			result.pass = not result.pass
+
+			assertPass(result)
 		end)
 	end)
 end)

--- a/src/matchers/equality.test.lua
+++ b/src/matchers/equality.test.lua
@@ -1,4 +1,5 @@
 local equality = require("src.matchers.equality")
+local prettyValue = require("src.utils.prettyValue")
 
 --- Asserts that a matcher passed
 ---@param result lest.TestResult Result of the matcher
@@ -174,7 +175,10 @@ describe("equality matchers", function()
 
 			assertFail(
 				result,
-				("Expected %s to deeply equal %s"):format(tableOne, tableTwo)
+				("Expected %s to deeply equal %s"):format(
+					prettyValue(tableOne),
+					prettyValue(tableTwo)
+				)
 			)
 		end)
 
@@ -247,8 +251,8 @@ describe("equality matchers", function()
 			assertFail(
 				result,
 				("Expected %s to not deeply equal %s"):format(
-					tableOne,
-					tableTwo
+					prettyValue(tableOne),
+					prettyValue(tableTwo)
 				)
 			)
 		end)
@@ -336,8 +340,8 @@ describe("equality matchers", function()
 			assertFail(
 				equality.toBeInstanceOf(CONTEXT, nonInstance, TestClass),
 				("Expected %s to be an instance of %s"):format(
-					nonInstance,
-					TestClass
+					prettyValue(nonInstance),
+					prettyValue(TestClass)
 				)
 			)
 		end)
@@ -349,8 +353,8 @@ describe("equality matchers", function()
 			assertFail(
 				result,
 				("Expected %s to not be an instance of %s"):format(
-					instance,
-					TestClass
+					prettyValue(instance),
+					prettyValue(TestClass)
 				)
 			)
 		end)


### PR DESCRIPTION
Overview:
- Implemented the scaffolds for the new equality matchers.
- Added unit tests for `equality.lua`. 100% code coverage. (toBeNil is an alias, so it isn't in the tests.)

## Questions
- Are these unit tests in good style?
- `toBeInstanceOf` is unclear. Should it act like JavaScript, scanning for multiple parent classes? Or.. should it just scan for the immediate parent class (**currently implemented as such**). In Lua, multiple inheritance is implemented in many ways. I don't think we could offer this functionality because the user's project might have implemented it differently.

This PR will remain as a draft until the questions are answered.