### PR TITLE
LEST-35 - Refactor Test Data Structure

### DIFF
--- a/src/runtime.lua
+++ b/src/runtime.lua
@@ -17,6 +17,9 @@ local function findTests(testFiles)
 	---@type lest.TestSuite | lest.Describe
 	local currentScope = tests
 
+	--- Registeres a new test suite
+	---@param name string
+	---@param func fun()
 	local function describe(name, func)
 		local prevScope = currentScope
 		currentScope = {

--- a/src/runtime.lua
+++ b/src/runtime.lua
@@ -120,8 +120,8 @@ local function runTests(tests)
 			if testOrDescribe.isDescribe then
 				results[testOrDescribe.name] = _runTests(
 					testOrDescribe,
-					tablex.merge(previousBeforeEach, testsToRun.beforeEach),
-					tablex.merge(previousAfterEach, testsToRun.afterEach)
+					tablex.squash(previousBeforeEach, testsToRun.beforeEach),
+					tablex.squash(previousAfterEach, testsToRun.afterEach)
 				)
 			else
 				runTest(testOrDescribe --[[@as lest.Test]]) -- LuaLS does not narrow by isDescribe

--- a/src/runtime.lua
+++ b/src/runtime.lua
@@ -17,7 +17,7 @@ local function findTests(testFiles)
 	---@type lest.TestSuite | lest.Describe
 	local currentScope = tests
 
-	--- Registeres a new test suite
+	--- Registers a new test suite
 	---@param name string
 	---@param func fun()
 	local function describe(name, func)
@@ -37,7 +37,7 @@ local function findTests(testFiles)
 		currentScope = prevScope
 	end
 
-	--- Registeres a new test
+	--- Registers a new test
 	---@param name string
 	---@param func fun()
 	local function test(name, func)

--- a/src/types.lua
+++ b/src/types.lua
@@ -12,3 +12,20 @@
 ---@class lest.MockResult
 ---@field type "return" | "throw"
 ---@field value any
+
+---@class lest.Test
+---@field name string
+---@field func fun()
+---@field isDescribe false
+
+---@class lest.TestSuite: { [number]: lest.Describe | lest.Test }
+---@field beforeEach fun()[]
+---@field beforeAll fun()[]
+---@field afterEach fun()[]
+---@field afterAll fun()[]
+
+---@class lest.Describe: lest.TestSuite
+---@field name string
+---@field isDescribe true
+
+---@class lest.TestResults: { [string]: lest.TestResult | lest.TestResults }

--- a/src/utils/tablex.lua
+++ b/src/utils/tablex.lua
@@ -19,18 +19,35 @@ return {
 	---@param ... table
 	---@return table
 	merge = function(...)
-		local merged
+		local merged = {}
 
 		for _, tbl in ipairs({ ... }) do
-			if merged then
-				for k, v in pairs(tbl) do
-					merged[k] = v
-				end
-			else
-				merged = tbl
+			for k, v in pairs(tbl) do
+				merged[k] = v
 			end
 		end
 
 		return merged or {}
+	end,
+
+	--- Appends the values of each array into a single array
+	---
+	--- Order of the elements is maintained
+	---@param ... any[]
+	---@return any[]
+	squash = function(...)
+		local squashed, offset = {}, 0
+
+		for _, tbl in ipairs({ ... }) do
+			local lastIndex = 0
+			for i, v in ipairs(tbl) do
+				squashed[i + offset] = v
+				lastIndex = i
+			end
+
+			offset = offset + lastIndex
+		end
+
+		return squashed
 	end,
 }


### PR DESCRIPTION
Refactors the test data structure to avoid name collision and to make handling easier and more efficient in code.

Also fixes some table bugs and adds `tablex.squash`.