### PR TITLE
LEST-34 - Add test job to CI

### DIFF
--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -16,3 +16,28 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest
           args: --check .
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        luaVersion:
+          [
+            "5.1.5",
+            "5.2.4",
+            "5.3.6",
+            "5.4.4",
+            "luajit-openresty",
+            "luajit-2.0.5",
+            "luajit-2.1.0-beta3",
+          ]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: leafo/gh-actions-lua@v10
+        with:
+          luaVersion: ${{ matrix.luaVersion }}
+
+      - name: test
+        run: lua lest.lua

--- a/lest.lua
+++ b/lest.lua
@@ -21,5 +21,9 @@ for _, filepath in ipairs(files) do
 	end
 end
 
-local results = runtime(testFiles)
+local tests = runtime.findTests(testFiles)
+local success, results = runtime.runTests(tests)
+
 printTable(results, 5)
+
+os.exit(success)

--- a/lest.lua
+++ b/lest.lua
@@ -26,4 +26,4 @@ local success, results = runtime.runTests(tests)
 
 printTable(results, 5)
 
-os.exit(success)
+os.exit(success and 0 or 1)

--- a/src/runtime.lua
+++ b/src/runtime.lua
@@ -81,8 +81,11 @@ end
 
 --- Runs all registered tests
 ---@param tests lest.TestSuite
----@return lest.TestResults
+---@return boolean success
+---@return lest.TestResults results
 local function runTests(tests)
+	local allTestsPassed = true
+
 	--- Internal test runner
 	---@param testsToRun lest.TestSuite | lest.Describe
 	---@param previousBeforeEach fun()[]
@@ -115,6 +118,7 @@ local function runTests(tests)
 			if success then
 				results[test.name] = { pass = true }
 			else
+				allTestsPassed = false
 				results[test.name] = { pass = false, error = err }
 			end
 		end
@@ -144,13 +148,7 @@ local function runTests(tests)
 
 	cleanup()
 
-	return results
+	return allTestsPassed, results
 end
 
---- Start a test runtime
----@param testFiles string[]
----@return lest.TestResults
-return function(testFiles)
-	local tests = findTests(testFiles)
-	return runTests(tests)
-end
+return { findTests = findTests, runTests = runTests }


### PR DESCRIPTION
Adds a matrix job to the CI workflow which tests Lest (using itself) on a variety of Lua versions.

Also modifies the runtime to expose finding and running tests individually (useful for the future editor extensions), to return a success boolean from the test runner, and to exit with `0`/`1` depending on whether the tests succeeded.