### PR TITLE
LEST-35 Markups - Fix results still using string keys

### DIFF
--- a/src/interface/testnodetype.lua
+++ b/src/interface/testnodetype.lua
@@ -1,8 +1,8 @@
----@enum lest.TestNodeType
-local TestNodeType = {
+---@enum lest.NodeType
+local NodeType = {
 	Test = 0,
 	Describe = 1,
 	Suite = 2,
 }
 
-return TestNodeType
+return NodeType

--- a/src/matchers/equality.test.lua
+++ b/src/matchers/equality.test.lua
@@ -2,13 +2,13 @@ local equality = require("src.matchers.equality")
 local prettyValue = require("src.utils.prettyValue")
 
 --- Asserts that a matcher passed
----@param result lest.TestResult Result of the matcher
+---@param result lest.MatcherResult Result of the matcher
 local function assertPass(result)
 	assert(result.pass, "test failed when it should have passed!")
 end
 
 --- Asserts that a matcher failed
----@param result lest.TestResult Result of the matcher
+---@param result lest.MatcherResult Result of the matcher
 ---@param expectedMsg string Expected message of the matcher
 local function assertFail(result, expectedMsg)
 	assert(result.message == expectedMsg, "test has an incorrect fail message!")

--- a/src/types.lua
+++ b/src/types.lua
@@ -3,18 +3,18 @@
 ---@class lest.MatcherContext
 ---@field inverted boolean -- True if the condition was inverted
 
----@class lest.TestResult
+---@class lest.MatcherResult
 ---@field pass boolean
 ---@field message string
 
----@alias lest.Matcher fun(ctx: lest.MatcherContext, received: any, ...: any): lest.TestResult
+---@alias lest.Matcher fun(ctx: lest.MatcherContext, received: any, ...: any): lest.MatcherResult
 
 ---@class lest.MockResult
 ---@field type "return" | "throw"
 ---@field value any
 
 ---@class lest.TestNode
----@field type lest.TestNodeType
+---@field type lest.NodeType
 ---@field name string
 
 ---@class lest.Test: lest.TestNode
@@ -33,4 +33,20 @@
 
 ---@class lest.Tests: { [number]: lest.TestSuite }
 
----@class lest.TestResults: { [string]: lest.TestResult | lest.TestResults }
+---@class lest.TestResultNode
+---@field type lest.NodeType
+---@field name string
+
+---@class lest.TestResult: lest.TestResultNode
+---@field type 0
+---@field pass boolean
+---@field error? any
+
+---@class lest.DescribeResults: { [number]: lest.TestResult | lest.DescribeResults }
+---@field type 1
+---@field name string
+
+---@class lest.TestSuiteResults: lest.DescribeResults
+---@field type 2
+
+---@class lest.TestResults: { [number]: lest.TestSuiteResults }


### PR DESCRIPTION
Fixes the tests results still storing results in string keys.