### PR TITLE
LEST-40 - Allow setting timeout on a per-file basis

### DIFF
--- a/src/runtime.lua
+++ b/src/runtime.lua
@@ -4,7 +4,17 @@ local tablex = require("src.utils.tablex")
 local withTimeout = require("src.utils.timeout")
 local NodeType = require("src.interface.testnodetype")
 
+lest = lest or {}
+
 local DEFAULT_TIMEOUT_SECONDS = 5
+local currentTimeoutSeconds = DEFAULT_TIMEOUT_SECONDS
+
+--- Sets the timeout for all hooks and tests in this suite
+---@param timeout number
+---@diagnostic disable-next-line: duplicate-set-field
+function lest.setTimeout(timeout)
+	currentTimeoutSeconds = timeout / 1000
+end
 
 --- Finds every test in the given files
 ---@param testFiles string[]
@@ -45,7 +55,7 @@ local function findTests(testFiles)
 			func = func,
 			name = name,
 			type = NodeType.Test,
-			timeout = timeout and (timeout / 1000) or DEFAULT_TIMEOUT_SECONDS,
+			timeout = timeout and (timeout / 1000) or currentTimeoutSeconds,
 		})
 	end
 
@@ -56,8 +66,7 @@ local function findTests(testFiles)
 		return function(func, timeout)
 			tablex.push(currentScope[key], {
 				func = func,
-				timeout = timeout and (timeout / 1000)
-					or DEFAULT_TIMEOUT_SECONDS,
+				timeout = timeout and (timeout / 1000) or currentTimeoutSeconds,
 			})
 		end
 	end
@@ -88,6 +97,7 @@ local function findTests(testFiles)
 		}
 
 		dofile(filepath)
+		currentTimeoutSeconds = DEFAULT_TIMEOUT_SECONDS
 
 		tablex.push(tests, currentScope)
 	end

--- a/src/utils/timeout.lua
+++ b/src/utils/timeout.lua
@@ -1,12 +1,22 @@
 local hook = require("src.utils.hook")
 local TimeoutError = require("src.errors.timeout")
 
+lest = lest or {}
+
 ---@diagnostic disable-next-line: deprecated
 local unpack = table.unpack or unpack
 
 local function withTimeout(timeout, func, ...)
 	local startTime = os.clock()
 	local timedOut = false
+
+	local oldSetTimeout = lest.setTimeout
+	function lest.setTimeout(newTimeout)
+		timeout = newTimeout / 1000
+		if oldSetTimeout then
+			oldSetTimeout(newTimeout)
+		end
+	end
 
 	local results = {
 		pcall(function(...)
@@ -22,6 +32,7 @@ local function withTimeout(timeout, func, ...)
 	}
 
 	hook.setCountHook()
+	lest.setTimeout = oldSetTimeout
 
 	return unpack(results)
 end

--- a/src/utils/timeout.test.lua
+++ b/src/utils/timeout.test.lua
@@ -46,4 +46,21 @@ describe("timeout", function()
 		expect(success).toBe(false)
 		expect(err).toBeInstanceOf(TimeoutError)
 	end)
+
+	it(
+		"should adjust the timeout with lest.setTimeout while running",
+		function()
+			-- Given
+			local func = function()
+				lest.setTimeout(-1)
+			end
+
+			-- When
+			local success, err = withTimeout(1000, func)
+
+			-- Then
+			expect(success).toBe(false)
+			expect(err).toBeInstanceOf(TimeoutError)
+		end
+	)
 end)


### PR DESCRIPTION
Adds `lest.setTimeout` which mimics the Jest equivalent.

Not only allows modifying the file's timeout, but allows modifying the timeout _while_ a hook/test is running.