### PR TITLE
LEST-41 - Allow setting global timeout via the config/CLI

### DIFF
--- a/lest.lua
+++ b/lest.lua
@@ -21,6 +21,12 @@ for _, filepath in ipairs(files) do
 	end
 end
 
+if options.testTimeout then
+	runtime.setDefaultTimeout(options.testTimeout)
+elseif config.testTimeout then
+	runtime.setDefaultTimeout(config.testTimeout)
+end
+
 local tests = runtime.findTests(testFiles)
 local success, results = runtime.runTests(tests)
 

--- a/src/runtime.lua
+++ b/src/runtime.lua
@@ -6,8 +6,14 @@ local NodeType = require("src.interface.testnodetype")
 
 lest = lest or {}
 
-local DEFAULT_TIMEOUT_SECONDS = 5
-local currentTimeoutSeconds = DEFAULT_TIMEOUT_SECONDS
+local defaultTimeoutSeconds = 5
+local currentTimeoutSeconds = defaultTimeoutSeconds
+
+--- Sets the timeout used by default
+---@param timeout number
+local function setDefaultTimeout(timeout)
+	defaultTimeoutSeconds = timeout / 1000
+end
 
 --- Sets the timeout for all hooks and tests in this suite
 ---@param timeout number
@@ -97,7 +103,7 @@ local function findTests(testFiles)
 		}
 
 		dofile(filepath)
-		currentTimeoutSeconds = DEFAULT_TIMEOUT_SECONDS
+		currentTimeoutSeconds = defaultTimeoutSeconds
 
 		tablex.push(tests, currentScope)
 	end
@@ -200,4 +206,8 @@ local function runTests(tests)
 	return allTestsPassed, results
 end
 
-return { findTests = findTests, runTests = runTests }
+return {
+	findTests = findTests,
+	runTests = runTests,
+	setDefaultTimeout = setDefaultTimeout,
+}


### PR DESCRIPTION
Adds the `testTimeout` option to both the CLI options and the config.

Removes unnecessary alias functionality from the CLI parameters.