### PR TITLE
LEST-28 - Implement remaining mock function matchers

### DIFF
--- a/src/matchers/mocks.lua
+++ b/src/matchers/mocks.lua
@@ -155,7 +155,7 @@ local function toHaveReturnedWith(ctx, received, ...)
 
 	local hasReturnedWithValues = false
 	for _, result in ipairs(received.mock.results) do
-		if deepEqual(retvals, result) then
+		if result.type == "return" and deepEqual(retvals, result.value) then
 			hasReturnedWithValues = true
 			break
 		end
@@ -179,7 +179,9 @@ local function toHaveLastReturnedWith(ctx, received, ...)
 	local retvals = { ... }
 
 	return {
-		pass = deepEqual(retvals, received.mock.lastResult),
+		pass = received.mock.lastResult
+			and received.mock.lastResult.type == "return"
+			and deepEqual(retvals, received.mock.lastResult.value),
 		message = string.format(
 			"Expected %s to%shave last returned with: %s",
 			tostring(received),
@@ -198,8 +200,9 @@ local function toHaveNthReturnedWith(ctx, received, nthCall, ...)
 	local retvals = { ... }
 
 	return {
-		pass = nthCall <= #received.mock.calls
-			and deepEqual(retvals, received.mock.results[nthCall]),
+		pass = nthCall <= #received.mock.results
+			and received.mock.results[nthCall].type == "return"
+			and deepEqual(retvals, received.mock.results[nthCall].value),
 		message = string.format(
 			"Expected %s to%shave Nth returned with: %s\nCall index: %i",
 			tostring(received),

--- a/tests/mocking.test.lua
+++ b/tests/mocking.test.lua
@@ -271,8 +271,8 @@ describe("lest.fn", function()
 			-- Given
 			mockFn
 				:mockReturnValueOnce("first call")
-				:mockReturnValueOnce(1, 2, 3, 4)
-				:mockReturnValueOnce("last call")
+				:mockReturnValueOnce("second call", 2, 3)
+				:mockReturnValueOnce("third call")
 
 			expect(mockFn).never.toHaveNthReturnedWith(2, "second call", 2, 3)
 

--- a/tests/mocking.test.lua
+++ b/tests/mocking.test.lua
@@ -166,7 +166,18 @@ describe("lest.fn", function()
 			expect(mockFn).toHaveBeenCalledTimes(1)
 		end)
 
-		xit("toHaveBeenCalledWith should pass", function() end)
+		it("toHaveBeenCalledWith should pass", function()
+			-- Given
+			expect(mockFn).never.toHaveBeenCalledWith(1, 2, 3, 4)
+
+			-- When
+			mockFn("first call")
+			mockFn(1, 2, 3, 4)
+			mockFn("last call")
+
+			-- Then
+			expect(mockFn).toHaveBeenCalledWith(1, 2, 3, 4)
+		end)
 
 		xit("toHaveBeenLastCalledWith should pass", function() end)
 

--- a/tests/mocking.test.lua
+++ b/tests/mocking.test.lua
@@ -191,7 +191,20 @@ describe("lest.fn", function()
 			expect(mockFn).toHaveBeenLastCalledWith(1, 2, 3, 4)
 		end)
 
-		xit("toHaveBeenNthCalledWith should pass", function() end)
+		it("toHaveBeenNthCalledWith should pass", function()
+			-- Given
+			expect(mockFn).never.toHaveBeenNthCalledWith(2, "second call", 2, 3)
+
+			-- When
+			mockFn("first call")
+			mockFn("second call", 2, 3)
+			mockFn("third call")
+
+			-- Then
+			expect(mockFn).toHaveBeenNthCalledWith(1, "first call")
+			expect(mockFn).toHaveBeenNthCalledWith(2, "second call", 2, 3)
+			expect(mockFn).toHaveBeenNthCalledWith(3, "third call")
+		end)
 
 		xit("toHaveReturned should pass", function() end)
 

--- a/tests/mocking.test.lua
+++ b/tests/mocking.test.lua
@@ -179,7 +179,17 @@ describe("lest.fn", function()
 			expect(mockFn).toHaveBeenCalledWith(1, 2, 3, 4)
 		end)
 
-		xit("toHaveBeenLastCalledWith should pass", function() end)
+		it("toHaveBeenLastCalledWith should pass", function()
+			-- Given
+			expect(mockFn).never.toHaveBeenLastCalledWith(1, 2, 3, 4)
+
+			-- When
+			mockFn("first call")
+			mockFn(1, 2, 3, 4)
+
+			-- Then
+			expect(mockFn).toHaveBeenLastCalledWith(1, 2, 3, 4)
+		end)
 
 		xit("toHaveBeenNthCalledWith should pass", function() end)
 

--- a/tests/mocking.test.lua
+++ b/tests/mocking.test.lua
@@ -157,13 +157,15 @@ describe("lest.fn", function()
 		it("toHaveBeenCalledTimes should pass", function()
 			-- Given
 			expect(mockFn).toHaveBeenCalledTimes(0)
-			expect(mockFn).never.toHaveBeenCalledTimes(1)
+			expect(mockFn).never.toHaveBeenCalledTimes(3)
 
 			-- When
 			mockFn()
+			mockFn()
+			mockFn()
 
 			-- Then
-			expect(mockFn).toHaveBeenCalledTimes(1)
+			expect(mockFn).toHaveBeenCalledTimes(3)
 		end)
 
 		it("toHaveBeenCalledWith should pass", function()
@@ -206,15 +208,84 @@ describe("lest.fn", function()
 			expect(mockFn).toHaveBeenNthCalledWith(3, "third call")
 		end)
 
-		xit("toHaveReturned should pass", function() end)
+		it("toHaveReturned should pass", function()
+			-- Given
+			expect(mockFn).never.toHaveReturned()
 
-		xit("toHaveReturnedTimes should pass", function() end)
+			-- When
+			mockFn()
 
-		xit("toHaveReturnedWith should pass", function() end)
+			-- Then
+			expect(mockFn).toHaveReturned()
+		end)
 
-		xit("toHaveLastReturnedWith should pass", function() end)
+		it("toHaveReturnedTimes should pass", function()
+			-- Given
+			expect(mockFn).toHaveReturnedTimes(0)
+			expect(mockFn).never.toHaveReturnedTimes(3)
 
-		xit("toHaveNthReturnedWith should pass", function() end)
+			-- When
+			mockFn()
+			mockFn()
+			mockFn()
+
+			-- Then
+			expect(mockFn).toHaveReturnedTimes(3)
+		end)
+
+		it("toHaveReturnedWith should pass", function()
+			-- Given
+			mockFn
+				:mockReturnValueOnce("first call")
+				:mockReturnValueOnce(1, 2, 3, 4)
+				:mockReturnValueOnce("last call")
+
+			expect(mockFn).never.toHaveReturnedWith(1, 2, 3, 4)
+
+			-- When
+			mockFn()
+			mockFn()
+			mockFn()
+
+			-- Then
+			expect(mockFn).toHaveReturnedWith(1, 2, 3, 4)
+		end)
+
+		it("toHaveLastReturnedWith should pass", function()
+			-- Given
+			mockFn
+				:mockReturnValueOnce("first call")
+				:mockReturnValueOnce(1, 2, 3, 4)
+
+			expect(mockFn).never.toHaveLastReturnedWith(1, 2, 3, 4)
+
+			-- When
+			mockFn()
+			mockFn()
+
+			-- Then
+			expect(mockFn).toHaveLastReturnedWith(1, 2, 3, 4)
+		end)
+
+		it("toHaveNthReturnedWith should pass", function()
+			-- Given
+			mockFn
+				:mockReturnValueOnce("first call")
+				:mockReturnValueOnce(1, 2, 3, 4)
+				:mockReturnValueOnce("last call")
+
+			expect(mockFn).never.toHaveNthReturnedWith(2, "second call", 2, 3)
+
+			-- When
+			mockFn("first call")
+			mockFn("second call", 2, 3)
+			mockFn("third call")
+
+			-- Then
+			expect(mockFn).toHaveNthReturnedWith(1, "first call")
+			expect(mockFn).toHaveNthReturnedWith(2, "second call", 2, 3)
+			expect(mockFn).toHaveNthReturnedWith(3, "third call")
+		end)
 	end)
 end)
 


### PR DESCRIPTION
Adds the remaining mock function matchers and the corresponding integration tests.

This does not add unit tests for the matchers as for now the integration tests at least guarantee they function. Unit tests should be added at some point.