### PR TITLE
LEST-29 - Number matchers

### DIFF
--- a/src/asserts/matchers.lua
+++ b/src/asserts/matchers.lua
@@ -1,26 +1,34 @@
 --- Asserts the matcher passed. TODO: move this into an asserts file in LEST-46
 ---@param result lest.MatcherResult
 local function assertPass(result)
-	assert(result.pass, "Expected matcher to pass")
+	if not result.pass then
+		error(debug.traceback("Expected matcher to pass", 2))
+	end
 end
 
 --- Asserts the matcher failed. TODO: move this into an asserts file in LEST-46
 ---@param result lest.MatcherResult
 local function assertFail(result)
-	assert(not result.pass, "Expected matcher to fail")
+	if result.pass then
+		error(debug.traceback("Expected matcher to fail", 2))
+	end
 end
 
 --- Asserts the matcher returned the given message. TODO: move this into an asserts file in LEST-46
 ---@param result lest.MatcherResult
 local function assertMessage(result, message)
-	assert(
-		result.message == message,
-		string.format(
-			"Expected message: %s\nReceived message: %s",
-			message,
-			result.message
+	if result.message ~= message then
+		error(
+			debug.traceback(
+				string.format(
+					"Expected message: %s\nReceived message: %s",
+					message,
+					result.message
+				),
+				2
+			)
 		)
-	)
+	end
 end
 
 return {

--- a/src/asserts/matchers.lua
+++ b/src/asserts/matchers.lua
@@ -1,34 +1,29 @@
---- Asserts the matcher passed. TODO: move this into an asserts file in LEST-46
+--- Asserts the matcher passed.
 ---@param result lest.MatcherResult
 local function assertPass(result)
-	if not result.pass then
-		error(debug.traceback("Expected matcher to pass", 2))
-	end
+	assert(result.pass, debug.traceback("Expected matcher to pass", 2))
 end
 
---- Asserts the matcher failed. TODO: move this into an asserts file in LEST-46
+--- Asserts the matcher failed.
 ---@param result lest.MatcherResult
 local function assertFail(result)
-	if result.pass then
-		error(debug.traceback("Expected matcher to fail", 2))
-	end
+	assert(not result.pass, debug.traceback("Expected matcher to fail", 2))
 end
 
---- Asserts the matcher returned the given message. TODO: move this into an asserts file in LEST-46
+--- Asserts the matcher returned the given message.
 ---@param result lest.MatcherResult
 local function assertMessage(result, message)
-	if result.message ~= message then
-		error(
-			debug.traceback(
-				string.format(
-					"Expected message: %s\nReceived message: %s",
-					message,
-					result.message
-				),
-				2
-			)
+	assert(
+		result.message == message,
+		debug.traceback(
+			string.format(
+				"Expected message: %s\nReceived message: %s",
+				message,
+				result.message
+			),
+			2
 		)
-	end
+	)
 end
 
 return {

--- a/src/matchers/numbers.lua
+++ b/src/matchers/numbers.lua
@@ -1,8 +1,36 @@
----@type lest.Matcher
-local function toBeCloseTo(ctx, received, expected, numDigits) end
+local prettyValue = require("src.utils.prettyValue")
 
 ---@type lest.Matcher
-local function toBeGreaterThan(ctx, received, expected) end
+local function toBeCloseTo(ctx, received, expected, numDigits)
+	local expectedDiff = math.pow(10, -numDigits) / 2
+	local receivedDiff = math.abs(expected - received)
+
+	local pass = receivedDiff < expectedDiff
+
+	return {
+		pass = pass,
+		message = string.format(
+			"Expected %s to%sbe close to %s within %s digits",
+			prettyValue(received),
+			ctx.inverted and " not " or " ",
+			prettyValue(expected),
+			prettyValue(numDigits)
+		),
+	}
+end
+
+---@type lest.Matcher
+local function toBeGreaterThan(ctx, received, expected)
+	return {
+		pass = received > expected,
+		message = string.format(
+			"Expected %s to%sbe greater than %s",
+			prettyValue(received),
+			ctx.inverted and " not " or " ",
+			prettyValue(expected)
+		),
+	}
+end
 
 ---@type lest.Matcher
 local function toBeGreaterThanOrEqual(ctx, received, expected) end
@@ -19,4 +47,7 @@ local function toBeNaN(ctx, received) end
 ---@type lest.Matcher
 local function toBeInfinity(ctx, received) end
 
-return {}
+return {
+	toBeCloseTo = toBeCloseTo,
+	toBeGreaterThan = toBeGreaterThan,
+}

--- a/src/matchers/numbers.lua
+++ b/src/matchers/numbers.lua
@@ -1,4 +1,5 @@
 local prettyValue = require("src.utils.prettyValue")
+local INFINITY = math.huge
 
 ---@type lest.Matcher
 local function toBeCloseTo(ctx, received, expected, numDigits)
@@ -33,21 +34,76 @@ local function toBeGreaterThan(ctx, received, expected)
 end
 
 ---@type lest.Matcher
-local function toBeGreaterThanOrEqual(ctx, received, expected) end
+local function toBeGreaterThanOrEqual(ctx, received, expected)
+	return {
+		pass = received >= expected,
+		message = string.format(
+			"Expected %s to%sbe greater than or equal to %s",
+			prettyValue(received),
+			ctx.inverted and " not " or " ",
+			prettyValue(expected)
+		),
+	}
+end
 
 ---@type lest.Matcher
-local function toBeLessThan(ctx, received, expected) end
+local function toBeLessThan(ctx, received, expected)
+	return {
+		pass = received < expected,
+		message = string.format(
+			"Expected %s to%sbe less than %s",
+			prettyValue(received),
+			ctx.inverted and " not " or " ",
+			prettyValue(expected)
+		),
+	}
+end
 
 ---@type lest.Matcher
-local function toBeLessThanOrEqual(ctx, received, expected) end
+local function toBeLessThanOrEqual(ctx, received, expected)
+	return {
+		pass = received <= expected,
+		message = string.format(
+			"Expected %s to%sbe less than or equal to %s",
+			prettyValue(received),
+			ctx.inverted and " not " or " ",
+			prettyValue(expected)
+		),
+	}
+end
 
 ---@type lest.Matcher
-local function toBeNaN(ctx, received) end
+local function toBeNaN(ctx, received)
+	return {
+		pass = received ~= received,
+		message = string.format(
+			"Expected %s to%sbe NaN",
+			prettyValue(received),
+			ctx.inverted and " not " or " "
+		),
+	}
+end
 
 ---@type lest.Matcher
-local function toBeInfinity(ctx, received) end
+local function toBeInfinity(ctx, received)
+	return {
+		pass = received == INFINITY,
+		message = string.format(
+			"Expected %s to%sbe infinity",
+			prettyValue(received),
+			ctx.inverted and " not " or " "
+		),
+	}
+end
 
 return {
 	toBeCloseTo = toBeCloseTo,
+
 	toBeGreaterThan = toBeGreaterThan,
+	toBeGreaterThanOrEqual = toBeGreaterThanOrEqual,
+	toBeLessThan = toBeLessThan,
+	toBeLessThanOrEqual = toBeLessThanOrEqual,
+
+	toBeNaN = toBeNaN,
+	toBeInfinity = toBeInfinity,
 }

--- a/src/matchers/numbers.lua
+++ b/src/matchers/numbers.lua
@@ -6,10 +6,8 @@ local function toBeCloseTo(ctx, received, expected, numDigits)
 	local expectedDiff = math.pow(10, -numDigits) / 2
 	local receivedDiff = math.abs(expected - received)
 
-	local pass = receivedDiff < expectedDiff
-
 	return {
-		pass = pass,
+		pass = receivedDiff < expectedDiff,
 		message = string.format(
 			"Expected %s to%sbe close to %s within %s digits",
 			prettyValue(received),

--- a/src/matchers/numbers.lua
+++ b/src/matchers/numbers.lua
@@ -1,11 +1,16 @@
 local prettyValue = require("src.utils.prettyValue")
+local assertType = require("src.asserts.type")
+
 local INFINITY = math.huge
 
 ---@type lest.Matcher
 local function toBeCloseTo(ctx, received, expected, numDigits)
+	assertType(received, "number")
+	assertType(expected, "number")
+	assertType(numDigits, "number")
+
 	local expectedDiff = math.pow(10, -numDigits) / 2
 	local receivedDiff = math.abs(expected - received)
-
 	return {
 		pass = receivedDiff < expectedDiff,
 		message = string.format(
@@ -20,6 +25,9 @@ end
 
 ---@type lest.Matcher
 local function toBeGreaterThan(ctx, received, expected)
+	assertType(received, "number")
+	assertType(expected, "number")
+
 	return {
 		pass = received > expected,
 		message = string.format(
@@ -33,6 +41,9 @@ end
 
 ---@type lest.Matcher
 local function toBeGreaterThanOrEqual(ctx, received, expected)
+	assertType(received, "number")
+	assertType(expected, "number")
+
 	return {
 		pass = received >= expected,
 		message = string.format(
@@ -46,6 +57,9 @@ end
 
 ---@type lest.Matcher
 local function toBeLessThan(ctx, received, expected)
+	assertType(received, "number")
+	assertType(expected, "number")
+
 	return {
 		pass = received < expected,
 		message = string.format(
@@ -59,6 +73,9 @@ end
 
 ---@type lest.Matcher
 local function toBeLessThanOrEqual(ctx, received, expected)
+	assertType(received, "number")
+	assertType(expected, "number")
+
 	return {
 		pass = received <= expected,
 		message = string.format(
@@ -72,6 +89,8 @@ end
 
 ---@type lest.Matcher
 local function toBeNaN(ctx, received)
+	assertType(received, "number")
+
 	return {
 		pass = received ~= received,
 		message = string.format(
@@ -84,6 +103,8 @@ end
 
 ---@type lest.Matcher
 local function toBeInfinity(ctx, received)
+	assertType(received, "number")
+
 	return {
 		pass = received == INFINITY,
 		message = string.format(

--- a/src/matchers/numbers.test.lua
+++ b/src/matchers/numbers.test.lua
@@ -145,13 +145,13 @@ describe("number matchers", function()
 	end)
 
 	describe("toBeGreaterThan", function()
-		-- Given
-		local greaterNumber = 10
-		local smallerNumber = 1
-
 		it(
 			"should pass when the received value is greater than the expected value",
 			function()
+				-- Given
+				local greaterNumber = 10
+				local smallerNumber = 1
+
 				-- When
 				local result = matchers.toBeGreaterThan(
 					CONTEXT,
@@ -167,6 +167,10 @@ describe("number matchers", function()
 		it(
 			"should fail when the received value is less than the expected value",
 			function()
+				-- Given
+				local greaterNumber = 10
+				local smallerNumber = 5
+
 				-- When
 				local result = matchers.toBeGreaterThan(
 					CONTEXT,
@@ -216,6 +220,10 @@ describe("number matchers", function()
 		end)
 
 		it("should have an inverted message", function()
+			-- Given
+			local greaterNumber = 10
+			local smallerNumber = 1
+
 			-- When
 			local result = matchers.toBeGreaterThan(
 				INVERTED_CONTEXT,
@@ -230,6 +238,400 @@ describe("number matchers", function()
 					greaterNumber,
 					smallerNumber
 				)
+			)
+		end)
+	end)
+
+	describe("toBeGreaterThanOrEqual", function()
+		it(
+			"should pass when the received value is greater than or equal to the expected value",
+			function()
+				-- Given
+				local greaterNumber = 10
+				local smallerNumber = 1
+				local equalNumber = greaterNumber
+
+				-- When
+				local result = matchers.toBeGreaterThanOrEqual(
+					CONTEXT,
+					greaterNumber,
+					smallerNumber
+				)
+
+				-- Then
+				assertMatcher.passed(result)
+
+				-- When
+				local resultEqual = matchers.toBeGreaterThanOrEqual(
+					CONTEXT,
+					greaterNumber,
+					equalNumber
+				)
+
+				-- Then
+				assertMatcher.passed(resultEqual)
+			end
+		)
+
+		it(
+			"should fail when the received value is less than the expected value",
+			function()
+				-- Given
+				local greaterNumber = 10
+				local smallerNumber = 3
+
+				-- When
+				local result = matchers.toBeGreaterThanOrEqual(
+					CONTEXT,
+					smallerNumber,
+					greaterNumber
+				)
+
+				-- Then
+				assertMatcher.failed(result)
+				assertMatcher.hasMessage(
+					result,
+					("Expected %d to be greater than or equal to %d"):format(
+						smallerNumber,
+						greaterNumber
+					)
+				)
+			end
+		)
+
+		it("should fail on NaN for any parameter", function()
+			-- Given
+			local normalNumber = 1
+
+			-- When
+			local result =
+				matchers.toBeGreaterThanOrEqual(CONTEXT, normalNumber, NAN)
+
+			local resultSwapped =
+				matchers.toBeGreaterThanOrEqual(CONTEXT, NAN, normalNumber)
+
+			-- Then
+			assertMatcher.failed(result)
+			assertMatcher.hasMessage(
+				result,
+				("Expected %d to be greater than or equal to %s"):format(
+					normalNumber,
+					tostring(NAN)
+				)
+			)
+			assertMatcher.failed(resultSwapped)
+			assertMatcher.hasMessage(
+				resultSwapped,
+				("Expected %s to be greater than or equal to %d"):format(
+					tostring(NAN),
+					normalNumber
+				)
+			)
+		end)
+
+		it("should have an inverted message", function()
+			-- Given
+			local greaterNumber = 10
+			local smallerNumber = 2
+			-- When
+			local result = matchers.toBeGreaterThanOrEqual(
+				INVERTED_CONTEXT,
+				greaterNumber,
+				smallerNumber
+			)
+
+			-- Then
+			assertMatcher.hasMessage(
+				result,
+				("Expected %d to not be greater than or equal to %d"):format(
+					greaterNumber,
+					smallerNumber
+				)
+			)
+		end)
+	end)
+
+	describe("toBeLessThan", function()
+		it(
+			"should pass when the received value is less than the expected value",
+			function()
+				-- Given
+				local greaterNumber = 10
+				local smallerNumber = 1
+
+				-- When
+				local result =
+					matchers.toBeLessThan(CONTEXT, smallerNumber, greaterNumber)
+
+				-- Then
+				assertMatcher.passed(result)
+			end
+		)
+
+		it(
+			"should fail when the received value is greater than the expected value",
+			function()
+				-- Given
+				local greaterNumber = 10
+				local smallerNumber = 5
+
+				-- When
+				local result =
+					matchers.toBeLessThan(CONTEXT, greaterNumber, smallerNumber)
+
+				-- Then
+				assertMatcher.failed(result)
+				assertMatcher.hasMessage(
+					result,
+					("Expected %d to be less than %d"):format(
+						greaterNumber,
+						smallerNumber
+					)
+				)
+			end
+		)
+
+		it("should fail on NaN for any parameter", function()
+			-- Given
+			local normalNumber = 1
+
+			-- When
+			local result = matchers.toBeLessThan(CONTEXT, normalNumber, NAN)
+
+			local resultSwapped =
+				matchers.toBeLessThan(CONTEXT, NAN, normalNumber)
+
+			-- Then
+			assertMatcher.failed(result)
+			assertMatcher.hasMessage(
+				result,
+				("Expected %d to be less than %s"):format(
+					normalNumber,
+					tostring(NAN)
+				)
+			)
+			assertMatcher.failed(resultSwapped)
+			assertMatcher.hasMessage(
+				resultSwapped,
+				("Expected %s to be less than %d"):format(
+					tostring(NAN),
+					normalNumber
+				)
+			)
+		end)
+
+		it("should have an inverted message", function()
+			-- Given
+			local greaterNumber = 10
+			local smallerNumber = 1
+
+			-- When
+			local result = matchers.toBeLessThan(
+				INVERTED_CONTEXT,
+				greaterNumber,
+				smallerNumber
+			)
+
+			-- Then
+			assertMatcher.hasMessage(
+				result,
+				("Expected %d to not be less than %d"):format(
+					greaterNumber,
+					smallerNumber
+				)
+			)
+		end)
+	end)
+
+	describe("toBeLessThanOrEqual", function()
+		it(
+			"should pass when the received value is less than or equal to the expected value",
+			function()
+				-- Given
+				local greaterNumber = 10
+				local smallerNumber = 1
+				local equalNumber = greaterNumber
+
+				-- When
+				local result = matchers.toBeLessThanOrEqual(
+					CONTEXT,
+					smallerNumber,
+					greaterNumber
+				)
+
+				-- Then
+				assertMatcher.passed(result)
+
+				-- When
+				local resultEqual = matchers.toBeLessThanOrEqual(
+					CONTEXT,
+					greaterNumber,
+					equalNumber
+				)
+
+				-- Then
+				assertMatcher.passed(resultEqual)
+			end
+		)
+
+		it(
+			"should fail when the received value is greater than the expected value",
+			function()
+				-- Given
+				local greaterNumber = 10
+				local smallerNumber = 3
+
+				-- When
+				local result = matchers.toBeLessThanOrEqual(
+					CONTEXT,
+					greaterNumber,
+					smallerNumber
+				)
+
+				-- Then
+				assertMatcher.failed(result)
+				assertMatcher.hasMessage(
+					result,
+					("Expected %d to be less than or equal to %d"):format(
+						greaterNumber,
+						smallerNumber
+					)
+				)
+			end
+		)
+
+		it("should fail on NaN for any parameter", function()
+			-- Given
+			local normalNumber = 1
+
+			-- When
+			local result =
+				matchers.toBeLessThanOrEqual(CONTEXT, normalNumber, NAN)
+
+			local resultSwapped =
+				matchers.toBeLessThanOrEqual(CONTEXT, NAN, normalNumber)
+
+			-- Then
+			assertMatcher.failed(result)
+			assertMatcher.hasMessage(
+				result,
+				("Expected %d to be less than or equal to %s"):format(
+					normalNumber,
+					tostring(NAN)
+				)
+			)
+			assertMatcher.failed(resultSwapped)
+			assertMatcher.hasMessage(
+				resultSwapped,
+				("Expected %s to be less than or equal to %d"):format(
+					tostring(NAN),
+					normalNumber
+				)
+			)
+		end)
+
+		it("should have an inverted message", function()
+			-- Given
+			local greaterNumber = 10
+			local smallerNumber = 2
+			-- When
+			local result = matchers.toBeLessThanOrEqual(
+				INVERTED_CONTEXT,
+				greaterNumber,
+				smallerNumber
+			)
+
+			-- Then
+			assertMatcher.hasMessage(
+				result,
+				("Expected %d to not be less than or equal to %d"):format(
+					greaterNumber,
+					smallerNumber
+				)
+			)
+		end)
+	end)
+
+	describe("toBeNaN", function()
+		it("should pass when the received value is NaN", function()
+			-- Given
+			local notANumber = 0 / 0
+
+			-- When
+			local result = matchers.toBeNaN(CONTEXT, notANumber)
+
+			-- Then
+			assertMatcher.passed(result)
+		end)
+
+		it("should fail when the received value isn't NaN", function()
+			-- Given
+			local normalNumber = 1
+
+			-- When
+			local result = matchers.toBeNaN(CONTEXT, normalNumber)
+
+			-- Then
+			assertMatcher.failed(result)
+			assertMatcher.hasMessage(
+				result,
+				("Expected %d to be NaN"):format(normalNumber)
+			)
+		end)
+
+		it("should have an inverted message", function()
+			-- Given
+			local notANumber = 0 / 0
+
+			-- When
+			local result = matchers.toBeNaN(INVERTED_CONTEXT, notANumber)
+
+			-- Then
+			assertMatcher.hasMessage(
+				result,
+				("Expected %s to not be NaN"):format(tostring(notANumber))
+			)
+		end)
+	end)
+
+	describe("toBeInfinity", function()
+		it("should pass when the received value is infinity", function()
+			-- Given
+			local inf = math.huge
+
+			-- When
+			local result = matchers.toBeInfinity(CONTEXT, inf)
+
+			-- Then
+			assertMatcher.passed(result)
+		end)
+
+		it("should fail when the received value isn't infinity", function()
+			-- Given
+			local normalNumber = 1
+
+			-- When
+			local result = matchers.toBeInfinity(CONTEXT, normalNumber)
+
+			-- Then
+			assertMatcher.failed(result)
+			assertMatcher.hasMessage(
+				result,
+				("Expected %d to be infinity"):format(normalNumber)
+			)
+		end)
+
+		it("should have an inverted message", function()
+			-- Given
+			local inf = math.huge
+
+			-- When
+			local result = matchers.toBeInfinity(INVERTED_CONTEXT, inf)
+
+			-- Then
+			assertMatcher.hasMessage(
+				result,
+				("Expected %s to not be infinity"):format(tostring(inf))
 			)
 		end)
 	end)

--- a/src/matchers/numbers.test.lua
+++ b/src/matchers/numbers.test.lua
@@ -1,7 +1,6 @@
 local matchers = require("src.matchers.numbers")
 local assertMatcher = require("src.asserts.matchers")
 
-local INFINITY = math.huge
 local NAN = 0 / 0
 
 describe("number matchers", function()
@@ -70,10 +69,10 @@ describe("number matchers", function()
 
 				-- When
 				local result =
-					matchers.toBeCloseTo(CONTEXT, normalNumber, INFINITY, 1)
+					matchers.toBeCloseTo(CONTEXT, normalNumber, math.huge, 1)
 
 				local resultSwapped =
-					matchers.toBeCloseTo(CONTEXT, INFINITY, normalNumber, 1)
+					matchers.toBeCloseTo(CONTEXT, math.huge, normalNumber, 1)
 
 				-- Then
 				assertMatcher.failed(result)
@@ -123,17 +122,13 @@ describe("number matchers", function()
 			end)
 
 			test("on infinity and NaN for both parameters", function()
-				-- Given
-				local negativeInf = -math.huge
-				local positiveInf = math.huge
-
 				-- When
 				local resultBothInf =
-					matchers.toBeCloseTo(CONTEXT, positiveInf, positiveInf)
+					matchers.toBeCloseTo(CONTEXT, math.huge, math.huge)
 				local resultPosInfNegInf =
-					matchers.toBeCloseTo(CONTEXT, positiveInf, negativeInf)
+					matchers.toBeCloseTo(CONTEXT, math.huge, -math.huge)
 				local resultBothNegInf =
-					matchers.toBeCloseTo(CONTEXT, positiveInf, positiveInf)
+					matchers.toBeCloseTo(CONTEXT, -math.huge, -math.huge)
 				local resultBothNan = matchers.toBeCloseTo(CONTEXT, NAN, NAN)
 
 				-- Then
@@ -146,8 +141,8 @@ describe("number matchers", function()
 				assertMatcher.hasMessage(
 					resultPosInfNegInf,
 					("Expected %s to be close to %s (2 decimal places)"):format(
-						tostring(positiveInf),
-						tostring(negativeInf)
+						tostring(math.huge),
+						tostring(-math.huge)
 					)
 				)
 
@@ -230,8 +225,8 @@ describe("number matchers", function()
 	describe("toBeInfinity", function()
 		it("should pass when the received value is infinity", function()
 			-- When
-			local resultPositive = matchers.toBeInfinity(CONTEXT, INFINITY)
-			local resultNegative = matchers.toBeInfinity(CONTEXT, -INFINITY)
+			local resultPositive = matchers.toBeInfinity(CONTEXT, math.huge)
+			local resultNegative = matchers.toBeInfinity(CONTEXT, -math.huge)
 
 			-- Then
 			assertMatcher.passed(resultPositive)
@@ -255,12 +250,12 @@ describe("number matchers", function()
 
 		it("should have an inverted message", function()
 			-- When
-			local result = matchers.toBeInfinity(INVERTED_CONTEXT, INFINITY)
+			local result = matchers.toBeInfinity(INVERTED_CONTEXT, math.huge)
 
 			-- Then
 			assertMatcher.hasMessage(
 				result,
-				("Expected %s to not be infinity"):format(tostring(INFINITY))
+				("Expected %s to not be infinity"):format(tostring(math.huge))
 			)
 		end)
 	end)

--- a/src/matchers/numbers.test.lua
+++ b/src/matchers/numbers.test.lua
@@ -1,0 +1,228 @@
+local matchers = require("src.matchers.numbers")
+local assertMatcher = require("src.asserts.matchers")
+
+local INFINITY = math.huge
+local NAN = 0 / 0
+
+describe("number matchers", function()
+	local CONTEXT = {
+		inverted = false,
+	}
+
+	local INVERTED_CONTEXT = {
+		inverted = true,
+	}
+
+	describe("toBeCloseTo", function()
+		local closeValue = 2.005
+		local testValue = 2
+
+		it(
+			"should pass when the received value is close to expected value",
+			function()
+				-- Given
+				local numDigits = 1
+
+				-- When
+				local result = matchers.toBeCloseTo(
+					CONTEXT,
+					closeValue,
+					testValue,
+					numDigits
+				)
+
+				-- Then
+				assertMatcher.passed(result)
+			end
+		)
+
+		it(
+			"should fail when the received value is not close to the expected value",
+			function()
+				-- Given
+				local numDigits = 3
+
+				-- When
+				local result = matchers.toBeCloseTo(
+					CONTEXT,
+					closeValue,
+					testValue,
+					numDigits
+				)
+
+				-- Then
+				assertMatcher.failed(result)
+				assertMatcher.hasMessage(
+					result,
+					("Expected %.3f to be close to %d within %d digits"):format(
+						closeValue,
+						testValue,
+						numDigits
+					)
+				)
+			end
+		)
+
+		it("should fail on infinity for any parameter", function()
+			-- Given
+			local normalNumber = 1
+
+			-- When
+			local result =
+				matchers.toBeCloseTo(CONTEXT, normalNumber, INFINITY, 1)
+
+			local resultSwapped =
+				matchers.toBeCloseTo(CONTEXT, INFINITY, normalNumber, 1)
+
+			-- Then
+			assertMatcher.failed(result)
+			assertMatcher.hasMessage(
+				result,
+				("Expected %d to be close to inf within 1 digits"):format(
+					normalNumber
+				)
+			)
+
+			assertMatcher.hasMessage(
+				resultSwapped,
+				("Expected inf to be close to %d within 1 digits"):format(
+					normalNumber
+				)
+			)
+		end)
+
+		it("should fail on NaN for any parameter", function()
+			-- Given
+			local normalNumber = 1
+
+			-- When
+			local result = matchers.toBeCloseTo(CONTEXT, normalNumber, NAN, 1)
+
+			local resultSwapped =
+				matchers.toBeCloseTo(CONTEXT, NAN, normalNumber, 1)
+
+			-- Then
+			assertMatcher.failed(result)
+			assertMatcher.hasMessage(
+				result,
+				("Expected %d to be close to nan within 1 digits"):format(
+					normalNumber
+				)
+			)
+			assertMatcher.failed(resultSwapped)
+			assertMatcher.hasMessage(
+				resultSwapped,
+				("Expected nan to be close to %d within 1 digits"):format(
+					normalNumber
+				)
+			)
+		end)
+
+		it("should have an inverted message", function()
+			-- Given
+			local numDigits = 1
+
+			-- When
+			local result = matchers.toBeCloseTo(
+				INVERTED_CONTEXT,
+				closeValue,
+				testValue,
+				numDigits
+			)
+
+			-- Then
+			assertMatcher.hasMessage(
+				result,
+				("Expected %.3f to not be close to %d within 1 digits"):format(
+					closeValue,
+					testValue,
+					numDigits
+				)
+			)
+		end)
+	end)
+
+	describe("toBeGreaterThan", function()
+		-- Given
+		local greaterNumber = 10
+		local smallerNumber = 1
+
+		it(
+			"should pass when the received value is greater than the expected value",
+			function()
+				-- When
+				local result = matchers.toBeGreaterThan(
+					CONTEXT,
+					greaterNumber,
+					smallerNumber
+				)
+
+				-- Then
+				assertMatcher.passed(result)
+			end
+		)
+
+		it(
+			"should fail when the received value is less than the expected value",
+			function()
+				-- When
+				local result = matchers.toBeGreaterThan(
+					CONTEXT,
+					smallerNumber,
+					greaterNumber
+				)
+
+				-- Then
+				assertMatcher.failed(result)
+				assertMatcher.hasMessage(
+					result,
+					("Expected %d to be greater than %d"):format(
+						smallerNumber,
+						greaterNumber
+					)
+				)
+			end
+		)
+
+		it("should fail on NaN for any parameter", function()
+			-- Given
+			local normalNumber = 1
+
+			-- When
+			local result = matchers.toBeGreaterThan(CONTEXT, normalNumber, NAN)
+
+			local resultSwapped =
+				matchers.toBeGreaterThan(CONTEXT, NAN, normalNumber)
+
+			-- Then
+			assertMatcher.failed(result)
+			assertMatcher.hasMessage(
+				result,
+				("Expected %d to be greater than nan"):format(normalNumber)
+			)
+			assertMatcher.failed(resultSwapped)
+			assertMatcher.hasMessage(
+				resultSwapped,
+				("Expected nan to be greater than %d"):format(normalNumber)
+			)
+		end)
+
+		it("should have an inverted message", function()
+			-- When
+			local result = matchers.toBeGreaterThan(
+				INVERTED_CONTEXT,
+				greaterNumber,
+				smallerNumber
+			)
+
+			-- Then
+			assertMatcher.hasMessage(
+				result,
+				("Expected %d to not be greater than %d"):format(
+					greaterNumber,
+					smallerNumber
+				)
+			)
+		end)
+	end)
+end)

--- a/src/matchers/numbers.test.lua
+++ b/src/matchers/numbers.test.lua
@@ -55,7 +55,7 @@ describe("number matchers", function()
 					assertMatcher.failed(result)
 					assertMatcher.hasMessage(
 						result,
-						("Expected %.3f to be close to %d within %d digits"):format(
+						("Expected %.3f to be close to %d (%d decimal places)"):format(
 							closeValue,
 							testValue,
 							numDigits
@@ -79,14 +79,14 @@ describe("number matchers", function()
 				assertMatcher.failed(result)
 				assertMatcher.hasMessage(
 					result,
-					("Expected %d to be close to inf within 1 digits"):format(
+					("Expected %d to be close to inf (1 decimal places)"):format(
 						normalNumber
 					)
 				)
 
 				assertMatcher.hasMessage(
 					resultSwapped,
-					("Expected inf to be close to %d within 1 digits"):format(
+					("Expected inf to be close to %d (1 decimal places)"):format(
 						normalNumber
 					)
 				)
@@ -107,7 +107,7 @@ describe("number matchers", function()
 				assertMatcher.failed(result)
 				assertMatcher.hasMessage(
 					result,
-					("Expected %d to be close to %s within 1 digits"):format(
+					("Expected %d to be close to %s (1 decimal places)"):format(
 						normalNumber,
 						tostring(NAN)
 					)
@@ -115,9 +115,47 @@ describe("number matchers", function()
 				assertMatcher.failed(resultSwapped)
 				assertMatcher.hasMessage(
 					resultSwapped,
-					("Expected %s to be close to %d within 1 digits"):format(
+					("Expected %s to be close to %d (1 decimal places)"):format(
 						tostring(NAN),
 						normalNumber
+					)
+				)
+			end)
+
+			test("on infinity and NaN for both parameters", function()
+				-- Given
+				local negativeInf = -math.huge
+				local positiveInf = math.huge
+
+				-- When
+				local resultBothInf =
+					matchers.toBeCloseTo(CONTEXT, positiveInf, positiveInf)
+				local resultPosInfNegInf =
+					matchers.toBeCloseTo(CONTEXT, positiveInf, negativeInf)
+				local resultBothNegInf =
+					matchers.toBeCloseTo(CONTEXT, positiveInf, positiveInf)
+				local resultBothNan = matchers.toBeCloseTo(CONTEXT, NAN, NAN)
+
+				-- Then
+				assertMatcher.passed(resultBothInf)
+				assertMatcher.passed(resultBothNegInf)
+
+				assertMatcher.failed(resultPosInfNegInf)
+				assertMatcher.failed(resultBothNan)
+
+				assertMatcher.hasMessage(
+					resultPosInfNegInf,
+					("Expected %s to be close to %s (2 decimal places)"):format(
+						tostring(positiveInf),
+						tostring(negativeInf)
+					)
+				)
+
+				assertMatcher.hasMessage(
+					resultBothNan,
+					("Expected %s to be close to %s (2 decimal places)"):format(
+						tostring(NAN),
+						tostring(NAN)
 					)
 				)
 			end)
@@ -138,430 +176,10 @@ describe("number matchers", function()
 			-- Then
 			assertMatcher.hasMessage(
 				result,
-				("Expected %.3f to not be close to %d within 1 digits"):format(
+				("Expected %.3f to not be close to %d (1 decimal places)"):format(
 					closeValue,
 					testValue,
 					numDigits
-				)
-			)
-		end)
-	end)
-
-	describe("toBeGreaterThan", function()
-		it(
-			"should pass when the received value is greater than the expected value",
-			function()
-				-- Given
-				local greaterNumber = 10
-				local smallerNumber = 1
-
-				-- When
-				local result = matchers.toBeGreaterThan(
-					CONTEXT,
-					greaterNumber,
-					smallerNumber
-				)
-
-				-- Then
-				assertMatcher.passed(result)
-			end
-		)
-
-		describe("should fail", function()
-			test(
-				"when the received value is less than the expected value",
-				function()
-					-- Given
-					local greaterNumber = 10
-					local smallerNumber = 5
-
-					-- When
-					local result = matchers.toBeGreaterThan(
-						CONTEXT,
-						smallerNumber,
-						greaterNumber
-					)
-
-					-- Then
-					assertMatcher.failed(result)
-					assertMatcher.hasMessage(
-						result,
-						("Expected %d to be greater than %d"):format(
-							smallerNumber,
-							greaterNumber
-						)
-					)
-				end
-			)
-
-			test("on NaN for any parameter", function()
-				-- Given
-				local normalNumber = 1
-
-				-- When
-				local result =
-					matchers.toBeGreaterThan(CONTEXT, normalNumber, NAN)
-
-				local resultSwapped =
-					matchers.toBeGreaterThan(CONTEXT, NAN, normalNumber)
-
-				-- Then
-				assertMatcher.failed(result)
-				assertMatcher.hasMessage(
-					result,
-					("Expected %d to be greater than %s"):format(
-						normalNumber,
-						tostring(NAN)
-					)
-				)
-				assertMatcher.failed(resultSwapped)
-				assertMatcher.hasMessage(
-					resultSwapped,
-					("Expected %s to be greater than %d"):format(
-						tostring(NAN),
-						normalNumber
-					)
-				)
-			end)
-		end)
-
-		it("should have an inverted message", function()
-			-- Given
-			local greaterNumber = 10
-			local smallerNumber = 1
-
-			-- When
-			local result = matchers.toBeGreaterThan(
-				INVERTED_CONTEXT,
-				greaterNumber,
-				smallerNumber
-			)
-
-			-- Then
-			assertMatcher.hasMessage(
-				result,
-				("Expected %d to not be greater than %d"):format(
-					greaterNumber,
-					smallerNumber
-				)
-			)
-		end)
-	end)
-
-	describe("toBeGreaterThanOrEqual", function()
-		it(
-			"should pass when the received value is greater than or equal to the expected value",
-			function()
-				-- Given
-				local greaterNumber = 10
-				local smallerNumber = 1
-				local equalNumber = greaterNumber
-
-				-- When
-				local result = matchers.toBeGreaterThanOrEqual(
-					CONTEXT,
-					greaterNumber,
-					smallerNumber
-				)
-
-				-- Then
-				assertMatcher.passed(result)
-
-				-- When
-				local resultEqual = matchers.toBeGreaterThanOrEqual(
-					CONTEXT,
-					greaterNumber,
-					equalNumber
-				)
-
-				-- Then
-				assertMatcher.passed(resultEqual)
-			end
-		)
-
-		describe("should fail", function()
-			test(
-				"when the received value is less than the expected value",
-				function()
-					-- Given
-					local greaterNumber = 10
-					local smallerNumber = 3
-
-					-- When
-					local result = matchers.toBeGreaterThanOrEqual(
-						CONTEXT,
-						smallerNumber,
-						greaterNumber
-					)
-
-					-- Then
-					assertMatcher.failed(result)
-					assertMatcher.hasMessage(
-						result,
-						("Expected %d to be greater than or equal to %d"):format(
-							smallerNumber,
-							greaterNumber
-						)
-					)
-				end
-			)
-
-			test("on NaN for any parameter", function()
-				-- Given
-				local normalNumber = 1
-
-				-- When
-				local result =
-					matchers.toBeGreaterThanOrEqual(CONTEXT, normalNumber, NAN)
-
-				local resultSwapped =
-					matchers.toBeGreaterThanOrEqual(CONTEXT, NAN, normalNumber)
-
-				-- Then
-				assertMatcher.failed(result)
-				assertMatcher.hasMessage(
-					result,
-					("Expected %d to be greater than or equal to %s"):format(
-						normalNumber,
-						tostring(NAN)
-					)
-				)
-				assertMatcher.failed(resultSwapped)
-				assertMatcher.hasMessage(
-					resultSwapped,
-					("Expected %s to be greater than or equal to %d"):format(
-						tostring(NAN),
-						normalNumber
-					)
-				)
-			end)
-		end)
-
-		it("should have an inverted message", function()
-			-- Given
-			local greaterNumber = 10
-			local smallerNumber = 2
-			-- When
-			local result = matchers.toBeGreaterThanOrEqual(
-				INVERTED_CONTEXT,
-				greaterNumber,
-				smallerNumber
-			)
-
-			-- Then
-			assertMatcher.hasMessage(
-				result,
-				("Expected %d to not be greater than or equal to %d"):format(
-					greaterNumber,
-					smallerNumber
-				)
-			)
-		end)
-	end)
-
-	describe("toBeLessThan", function()
-		it(
-			"should pass when the received value is less than the expected value",
-			function()
-				-- Given
-				local greaterNumber = 10
-				local smallerNumber = 1
-
-				-- When
-				local result =
-					matchers.toBeLessThan(CONTEXT, smallerNumber, greaterNumber)
-
-				-- Then
-				assertMatcher.passed(result)
-			end
-		)
-
-		describe("should fail", function()
-			test(
-				"when the received value is greater than the expected value",
-				function()
-					-- Given
-					local greaterNumber = 10
-					local smallerNumber = 5
-
-					-- When
-					local result = matchers.toBeLessThan(
-						CONTEXT,
-						greaterNumber,
-						smallerNumber
-					)
-
-					-- Then
-					assertMatcher.failed(result)
-					assertMatcher.hasMessage(
-						result,
-						("Expected %d to be less than %d"):format(
-							greaterNumber,
-							smallerNumber
-						)
-					)
-				end
-			)
-
-			test("on NaN for any parameter", function()
-				-- Given
-				local normalNumber = 1
-
-				-- When
-				local result = matchers.toBeLessThan(CONTEXT, normalNumber, NAN)
-
-				local resultSwapped =
-					matchers.toBeLessThan(CONTEXT, NAN, normalNumber)
-
-				-- Then
-				assertMatcher.failed(result)
-				assertMatcher.hasMessage(
-					result,
-					("Expected %d to be less than %s"):format(
-						normalNumber,
-						tostring(NAN)
-					)
-				)
-				assertMatcher.failed(resultSwapped)
-				assertMatcher.hasMessage(
-					resultSwapped,
-					("Expected %s to be less than %d"):format(
-						tostring(NAN),
-						normalNumber
-					)
-				)
-			end)
-		end)
-
-		it("should have an inverted message", function()
-			-- Given
-			local greaterNumber = 10
-			local smallerNumber = 1
-
-			-- When
-			local result = matchers.toBeLessThan(
-				INVERTED_CONTEXT,
-				greaterNumber,
-				smallerNumber
-			)
-
-			-- Then
-			assertMatcher.hasMessage(
-				result,
-				("Expected %d to not be less than %d"):format(
-					greaterNumber,
-					smallerNumber
-				)
-			)
-		end)
-	end)
-
-	describe("toBeLessThanOrEqual", function()
-		it(
-			"should pass when the received value is less than or equal to the expected value",
-			function()
-				-- Given
-				local greaterNumber = 10
-				local smallerNumber = 1
-				local equalNumber = greaterNumber
-
-				-- When
-				local result = matchers.toBeLessThanOrEqual(
-					CONTEXT,
-					smallerNumber,
-					greaterNumber
-				)
-
-				-- Then
-				assertMatcher.passed(result)
-
-				-- When
-				local resultEqual = matchers.toBeLessThanOrEqual(
-					CONTEXT,
-					greaterNumber,
-					equalNumber
-				)
-
-				-- Then
-				assertMatcher.passed(resultEqual)
-			end
-		)
-
-		describe("should fail", function()
-			test(
-				"when the received value is greater than the expected value",
-				function()
-					-- Given
-					local greaterNumber = 10
-					local smallerNumber = 3
-
-					-- When
-					local result = matchers.toBeLessThanOrEqual(
-						CONTEXT,
-						greaterNumber,
-						smallerNumber
-					)
-
-					-- Then
-					assertMatcher.failed(result)
-					assertMatcher.hasMessage(
-						result,
-						("Expected %d to be less than or equal to %d"):format(
-							greaterNumber,
-							smallerNumber
-						)
-					)
-				end
-			)
-
-			test("on NaN for any parameter", function()
-				-- Given
-				local normalNumber = 1
-
-				-- When
-				local result =
-					matchers.toBeLessThanOrEqual(CONTEXT, normalNumber, NAN)
-
-				local resultSwapped =
-					matchers.toBeLessThanOrEqual(CONTEXT, NAN, normalNumber)
-
-				-- Then
-				assertMatcher.failed(result)
-				assertMatcher.hasMessage(
-					result,
-					("Expected %d to be less than or equal to %s"):format(
-						normalNumber,
-						tostring(NAN)
-					)
-				)
-				assertMatcher.failed(resultSwapped)
-				assertMatcher.hasMessage(
-					resultSwapped,
-					("Expected %s to be less than or equal to %d"):format(
-						tostring(NAN),
-						normalNumber
-					)
-				)
-			end)
-		end)
-
-		it("should have an inverted message", function()
-			-- Given
-			local greaterNumber = 10
-			local smallerNumber = 2
-			-- When
-			local result = matchers.toBeLessThanOrEqual(
-				INVERTED_CONTEXT,
-				greaterNumber,
-				smallerNumber
-			)
-
-			-- Then
-			assertMatcher.hasMessage(
-				result,
-				("Expected %d to not be less than or equal to %d"):format(
-					greaterNumber,
-					smallerNumber
 				)
 			)
 		end)
@@ -611,14 +229,13 @@ describe("number matchers", function()
 
 	describe("toBeInfinity", function()
 		it("should pass when the received value is infinity", function()
-			-- Given
-			local inf = math.huge
-
 			-- When
-			local result = matchers.toBeInfinity(CONTEXT, inf)
+			local resultPositive = matchers.toBeInfinity(CONTEXT, INFINITY)
+			local resultNegative = matchers.toBeInfinity(CONTEXT, -INFINITY)
 
 			-- Then
-			assertMatcher.passed(result)
+			assertMatcher.passed(resultPositive)
+			assertMatcher.passed(resultNegative)
 		end)
 
 		it("should fail when the received value isn't infinity", function()
@@ -637,16 +254,13 @@ describe("number matchers", function()
 		end)
 
 		it("should have an inverted message", function()
-			-- Given
-			local inf = math.huge
-
 			-- When
-			local result = matchers.toBeInfinity(INVERTED_CONTEXT, inf)
+			local result = matchers.toBeInfinity(INVERTED_CONTEXT, INFINITY)
 
 			-- Then
 			assertMatcher.hasMessage(
 				result,
-				("Expected %s to not be infinity"):format(tostring(inf))
+				("Expected %s to not be infinity"):format(tostring(INFINITY))
 			)
 		end)
 	end)

--- a/src/matchers/numbers.test.lua
+++ b/src/matchers/numbers.test.lua
@@ -105,14 +105,16 @@ describe("number matchers", function()
 			assertMatcher.failed(result)
 			assertMatcher.hasMessage(
 				result,
-				("Expected %d to be close to nan within 1 digits"):format(
-					normalNumber
+				("Expected %d to be close to %s within 1 digits"):format(
+					normalNumber,
+					tostring(NAN)
 				)
 			)
 			assertMatcher.failed(resultSwapped)
 			assertMatcher.hasMessage(
 				resultSwapped,
-				("Expected nan to be close to %d within 1 digits"):format(
+				("Expected %s to be close to %d within 1 digits"):format(
+					tostring(NAN),
 					normalNumber
 				)
 			)
@@ -198,12 +200,18 @@ describe("number matchers", function()
 			assertMatcher.failed(result)
 			assertMatcher.hasMessage(
 				result,
-				("Expected %d to be greater than nan"):format(normalNumber)
+				("Expected %d to be greater than %s"):format(
+					normalNumber,
+					tostring(NAN)
+				)
 			)
 			assertMatcher.failed(resultSwapped)
 			assertMatcher.hasMessage(
 				resultSwapped,
-				("Expected nan to be greater than %d"):format(normalNumber)
+				("Expected %s to be greater than %d"):format(
+					tostring(NAN),
+					normalNumber
+				)
 			)
 		end)
 

--- a/src/matchers/numbers.test.lua
+++ b/src/matchers/numbers.test.lua
@@ -180,6 +180,307 @@ describe("number matchers", function()
 		end)
 	end)
 
+	describe("toBeGreaterThan", function()
+		it(
+			"should pass when the received value is greater than the expected value",
+			function()
+				-- Given
+				local greaterNumber = 10
+				local smallerNumber = 1
+
+				-- When
+				local result = matchers.toBeGreaterThan(
+					CONTEXT,
+					greaterNumber,
+					smallerNumber
+				)
+
+				-- Then
+				assertMatcher.passed(result)
+			end
+		)
+
+		describe("should fail", function()
+			test(
+				"when the received value is less than the expected value",
+				function()
+					-- Given
+					local greaterNumber = 10
+					local smallerNumber = 5
+
+					-- When
+					local result = matchers.toBeGreaterThan(
+						CONTEXT,
+						smallerNumber,
+						greaterNumber
+					)
+
+					-- Then
+					assertMatcher.failed(result)
+					assertMatcher.hasMessage(
+						result,
+						("Expected %d to be greater than %d"):format(
+							smallerNumber,
+							greaterNumber
+						)
+					)
+				end
+			)
+		end)
+
+		it("should have an inverted message", function()
+			-- Given
+			local greaterNumber = 10
+			local smallerNumber = 1
+
+			-- When
+			local result = matchers.toBeGreaterThan(
+				INVERTED_CONTEXT,
+				greaterNumber,
+				smallerNumber
+			)
+
+			-- Then
+			assertMatcher.hasMessage(
+				result,
+				("Expected %d to not be greater than %d"):format(
+					greaterNumber,
+					smallerNumber
+				)
+			)
+		end)
+	end)
+
+	describe("toBeGreaterThanOrEqual", function()
+		it(
+			"should pass when the received value is greater than or equal to the expected value",
+			function()
+				-- Given
+				local greaterNumber = 10
+				local smallerNumber = 1
+				local equalNumber = greaterNumber
+
+				-- When
+				local result = matchers.toBeGreaterThanOrEqual(
+					CONTEXT,
+					greaterNumber,
+					smallerNumber
+				)
+
+				-- Then
+				assertMatcher.passed(result)
+
+				-- When
+				local resultEqual = matchers.toBeGreaterThanOrEqual(
+					CONTEXT,
+					greaterNumber,
+					equalNumber
+				)
+
+				-- Then
+				assertMatcher.passed(resultEqual)
+			end
+		)
+
+		describe("should fail", function()
+			test(
+				"when the received value is less than the expected value",
+				function()
+					-- Given
+					local greaterNumber = 10
+					local smallerNumber = 3
+
+					-- When
+					local result = matchers.toBeGreaterThanOrEqual(
+						CONTEXT,
+						smallerNumber,
+						greaterNumber
+					)
+
+					-- Then
+					assertMatcher.failed(result)
+					assertMatcher.hasMessage(
+						result,
+						("Expected %d to be greater than or equal to %d"):format(
+							smallerNumber,
+							greaterNumber
+						)
+					)
+				end
+			)
+		end)
+
+		it("should have an inverted message", function()
+			-- Given
+			local greaterNumber = 10
+			local smallerNumber = 2
+			-- When
+			local result = matchers.toBeGreaterThanOrEqual(
+				INVERTED_CONTEXT,
+				greaterNumber,
+				smallerNumber
+			)
+
+			-- Then
+			assertMatcher.hasMessage(
+				result,
+				("Expected %d to not be greater than or equal to %d"):format(
+					greaterNumber,
+					smallerNumber
+				)
+			)
+		end)
+	end)
+
+	describe("toBeLessThan", function()
+		it(
+			"should pass when the received value is less than the expected value",
+			function()
+				-- Given
+				local greaterNumber = 10
+				local smallerNumber = 1
+
+				-- When
+				local result =
+					matchers.toBeLessThan(CONTEXT, smallerNumber, greaterNumber)
+
+				-- Then
+				assertMatcher.passed(result)
+			end
+		)
+
+		describe("should fail", function()
+			test(
+				"when the received value is greater than the expected value",
+				function()
+					-- Given
+					local greaterNumber = 10
+					local smallerNumber = 5
+
+					-- When
+					local result = matchers.toBeLessThan(
+						CONTEXT,
+						greaterNumber,
+						smallerNumber
+					)
+
+					-- Then
+					assertMatcher.failed(result)
+					assertMatcher.hasMessage(
+						result,
+						("Expected %d to be less than %d"):format(
+							greaterNumber,
+							smallerNumber
+						)
+					)
+				end
+			)
+		end)
+
+		it("should have an inverted message", function()
+			-- Given
+			local greaterNumber = 10
+			local smallerNumber = 1
+
+			-- When
+			local result = matchers.toBeLessThan(
+				INVERTED_CONTEXT,
+				greaterNumber,
+				smallerNumber
+			)
+
+			-- Then
+			assertMatcher.hasMessage(
+				result,
+				("Expected %d to not be less than %d"):format(
+					greaterNumber,
+					smallerNumber
+				)
+			)
+		end)
+	end)
+
+	describe("toBeLessThanOrEqual", function()
+		it(
+			"should pass when the received value is less than or equal to the expected value",
+			function()
+				-- Given
+				local greaterNumber = 10
+				local smallerNumber = 1
+				local equalNumber = greaterNumber
+
+				-- When
+				local result = matchers.toBeLessThanOrEqual(
+					CONTEXT,
+					smallerNumber,
+					greaterNumber
+				)
+
+				-- Then
+				assertMatcher.passed(result)
+
+				-- When
+				local resultEqual = matchers.toBeLessThanOrEqual(
+					CONTEXT,
+					greaterNumber,
+					equalNumber
+				)
+
+				-- Then
+				assertMatcher.passed(resultEqual)
+			end
+		)
+
+		describe("should fail", function()
+			test(
+				"when the received value is greater than the expected value",
+				function()
+					-- Given
+					local greaterNumber = 10
+					local smallerNumber = 3
+
+					-- When
+					local result = matchers.toBeLessThanOrEqual(
+						CONTEXT,
+						greaterNumber,
+						smallerNumber
+					)
+
+					-- Then
+					assertMatcher.failed(result)
+					assertMatcher.hasMessage(
+						result,
+						("Expected %d to be less than or equal to %d"):format(
+							greaterNumber,
+							smallerNumber
+						)
+					)
+				end
+			)
+		end)
+
+		it("should have an inverted message", function()
+			-- Given
+			local greaterNumber = 10
+			local smallerNumber = 2
+			-- When
+			local result = matchers.toBeLessThanOrEqual(
+				INVERTED_CONTEXT,
+				greaterNumber,
+				smallerNumber
+			)
+
+			-- Then
+			assertMatcher.hasMessage(
+				result,
+				("Expected %d to not be less than or equal to %d"):format(
+					greaterNumber,
+					smallerNumber
+				)
+			)
+		end)
+	end)
+
 	describe("toBeNaN", function()
 		it("should pass when the received value is NaN", function()
 			-- Given

--- a/src/matchers/numbers.test.lua
+++ b/src/matchers/numbers.test.lua
@@ -36,88 +36,91 @@ describe("number matchers", function()
 			end
 		)
 
-		it(
-			"should fail when the received value is not close to the expected value",
-			function()
+		describe("should fail", function()
+			test(
+				"when the received value is not close to the expected value",
+				function()
+					-- Given
+					local numDigits = 3
+
+					-- When
+					local result = matchers.toBeCloseTo(
+						CONTEXT,
+						closeValue,
+						testValue,
+						numDigits
+					)
+
+					-- Then
+					assertMatcher.failed(result)
+					assertMatcher.hasMessage(
+						result,
+						("Expected %.3f to be close to %d within %d digits"):format(
+							closeValue,
+							testValue,
+							numDigits
+						)
+					)
+				end
+			)
+
+			test("on infinity for any parameter", function()
 				-- Given
-				local numDigits = 3
+				local normalNumber = 1
 
 				-- When
-				local result = matchers.toBeCloseTo(
-					CONTEXT,
-					closeValue,
-					testValue,
-					numDigits
-				)
+				local result =
+					matchers.toBeCloseTo(CONTEXT, normalNumber, INFINITY, 1)
+
+				local resultSwapped =
+					matchers.toBeCloseTo(CONTEXT, INFINITY, normalNumber, 1)
 
 				-- Then
 				assertMatcher.failed(result)
 				assertMatcher.hasMessage(
 					result,
-					("Expected %.3f to be close to %d within %d digits"):format(
-						closeValue,
-						testValue,
-						numDigits
+					("Expected %d to be close to inf within 1 digits"):format(
+						normalNumber
 					)
 				)
-			end
-		)
 
-		it("should fail on infinity for any parameter", function()
-			-- Given
-			local normalNumber = 1
-
-			-- When
-			local result =
-				matchers.toBeCloseTo(CONTEXT, normalNumber, INFINITY, 1)
-
-			local resultSwapped =
-				matchers.toBeCloseTo(CONTEXT, INFINITY, normalNumber, 1)
-
-			-- Then
-			assertMatcher.failed(result)
-			assertMatcher.hasMessage(
-				result,
-				("Expected %d to be close to inf within 1 digits"):format(
-					normalNumber
+				assertMatcher.hasMessage(
+					resultSwapped,
+					("Expected inf to be close to %d within 1 digits"):format(
+						normalNumber
+					)
 				)
-			)
+			end)
 
-			assertMatcher.hasMessage(
-				resultSwapped,
-				("Expected inf to be close to %d within 1 digits"):format(
-					normalNumber
+			test("on NaN for any parameter", function()
+				-- Given
+				local normalNumber = 1
+
+				-- When
+				local result =
+					matchers.toBeCloseTo(CONTEXT, normalNumber, NAN, 1)
+
+				local resultSwapped =
+					matchers.toBeCloseTo(CONTEXT, NAN, normalNumber, 1)
+
+				-- Then
+				assertMatcher.failed(result)
+				assertMatcher.hasMessage(
+					result,
+					("Expected %d to be close to %s within 1 digits"):format(
+						normalNumber,
+						tostring(NAN)
+					)
 				)
-			)
-		end)
-
-		it("should fail on NaN for any parameter", function()
-			-- Given
-			local normalNumber = 1
-
-			-- When
-			local result = matchers.toBeCloseTo(CONTEXT, normalNumber, NAN, 1)
-
-			local resultSwapped =
-				matchers.toBeCloseTo(CONTEXT, NAN, normalNumber, 1)
-
-			-- Then
-			assertMatcher.failed(result)
-			assertMatcher.hasMessage(
-				result,
-				("Expected %d to be close to %s within 1 digits"):format(
-					normalNumber,
-					tostring(NAN)
+				assertMatcher.failed(resultSwapped)
+				assertMatcher.hasMessage(
+					resultSwapped,
+					("Expected %s to be close to %d within 1 digits"):format(
+						tostring(NAN),
+						normalNumber
+					)
 				)
-			)
-			assertMatcher.failed(resultSwapped)
-			assertMatcher.hasMessage(
-				resultSwapped,
-				("Expected %s to be close to %d within 1 digits"):format(
-					tostring(NAN),
-					normalNumber
-				)
-			)
+			end)
 		end)
 
 		it("should have an inverted message", function()
@@ -164,59 +167,62 @@ describe("number matchers", function()
 			end
 		)
 
-		it(
-			"should fail when the received value is less than the expected value",
-			function()
+		describe("should fail", function()
+			test(
+				"when the received value is less than the expected value",
+				function()
+					-- Given
+					local greaterNumber = 10
+					local smallerNumber = 5
+
+					-- When
+					local result = matchers.toBeGreaterThan(
+						CONTEXT,
+						smallerNumber,
+						greaterNumber
+					)
+
+					-- Then
+					assertMatcher.failed(result)
+					assertMatcher.hasMessage(
+						result,
+						("Expected %d to be greater than %d"):format(
+							smallerNumber,
+							greaterNumber
+						)
+					)
+				end
+			)
+
+			test("on NaN for any parameter", function()
 				-- Given
-				local greaterNumber = 10
-				local smallerNumber = 5
+				local normalNumber = 1
 
 				-- When
-				local result = matchers.toBeGreaterThan(
-					CONTEXT,
-					smallerNumber,
-					greaterNumber
-				)
+				local result =
+					matchers.toBeGreaterThan(CONTEXT, normalNumber, NAN)
+
+				local resultSwapped =
+					matchers.toBeGreaterThan(CONTEXT, NAN, normalNumber)
 
 				-- Then
 				assertMatcher.failed(result)
 				assertMatcher.hasMessage(
 					result,
-					("Expected %d to be greater than %d"):format(
-						smallerNumber,
-						greaterNumber
+					("Expected %d to be greater than %s"):format(
+						normalNumber,
+						tostring(NAN)
 					)
 				)
-			end
-		)
-
-		it("should fail on NaN for any parameter", function()
-			-- Given
-			local normalNumber = 1
-
-			-- When
-			local result = matchers.toBeGreaterThan(CONTEXT, normalNumber, NAN)
-
-			local resultSwapped =
-				matchers.toBeGreaterThan(CONTEXT, NAN, normalNumber)
-
-			-- Then
-			assertMatcher.failed(result)
-			assertMatcher.hasMessage(
-				result,
-				("Expected %d to be greater than %s"):format(
-					normalNumber,
-					tostring(NAN)
+				assertMatcher.failed(resultSwapped)
+				assertMatcher.hasMessage(
+					resultSwapped,
+					("Expected %s to be greater than %d"):format(
+						tostring(NAN),
+						normalNumber
+					)
 				)
-			)
-			assertMatcher.failed(resultSwapped)
-			assertMatcher.hasMessage(
-				resultSwapped,
-				("Expected %s to be greater than %d"):format(
-					tostring(NAN),
-					normalNumber
-				)
-			)
+			end)
 		end)
 
 		it("should have an inverted message", function()
@@ -273,60 +279,62 @@ describe("number matchers", function()
 			end
 		)
 
-		it(
-			"should fail when the received value is less than the expected value",
-			function()
+		describe("should fail", function()
+			test(
+				"when the received value is less than the expected value",
+				function()
+					-- Given
+					local greaterNumber = 10
+					local smallerNumber = 3
+
+					-- When
+					local result = matchers.toBeGreaterThanOrEqual(
+						CONTEXT,
+						smallerNumber,
+						greaterNumber
+					)
+
+					-- Then
+					assertMatcher.failed(result)
+					assertMatcher.hasMessage(
+						result,
+						("Expected %d to be greater than or equal to %d"):format(
+							smallerNumber,
+							greaterNumber
+						)
+					)
+				end
+			)
+
+			test("on NaN for any parameter", function()
 				-- Given
-				local greaterNumber = 10
-				local smallerNumber = 3
+				local normalNumber = 1
 
 				-- When
-				local result = matchers.toBeGreaterThanOrEqual(
-					CONTEXT,
-					smallerNumber,
-					greaterNumber
-				)
+				local result =
+					matchers.toBeGreaterThanOrEqual(CONTEXT, normalNumber, NAN)
+
+				local resultSwapped =
+					matchers.toBeGreaterThanOrEqual(CONTEXT, NAN, normalNumber)
 
 				-- Then
 				assertMatcher.failed(result)
 				assertMatcher.hasMessage(
 					result,
-					("Expected %d to be greater than or equal to %d"):format(
-						smallerNumber,
-						greaterNumber
+					("Expected %d to be greater than or equal to %s"):format(
+						normalNumber,
+						tostring(NAN)
 					)
 				)
-			end
-		)
-
-		it("should fail on NaN for any parameter", function()
-			-- Given
-			local normalNumber = 1
-
-			-- When
-			local result =
-				matchers.toBeGreaterThanOrEqual(CONTEXT, normalNumber, NAN)
-
-			local resultSwapped =
-				matchers.toBeGreaterThanOrEqual(CONTEXT, NAN, normalNumber)
-
-			-- Then
-			assertMatcher.failed(result)
-			assertMatcher.hasMessage(
-				result,
-				("Expected %d to be greater than or equal to %s"):format(
-					normalNumber,
-					tostring(NAN)
+				assertMatcher.failed(resultSwapped)
+				assertMatcher.hasMessage(
+					resultSwapped,
+					("Expected %s to be greater than or equal to %d"):format(
+						tostring(NAN),
+						normalNumber
+					)
 				)
-			)
-			assertMatcher.failed(resultSwapped)
-			assertMatcher.hasMessage(
-				resultSwapped,
-				("Expected %s to be greater than or equal to %d"):format(
-					tostring(NAN),
-					normalNumber
-				)
-			)
+			end)
 		end)
 
 		it("should have an inverted message", function()
@@ -368,56 +376,61 @@ describe("number matchers", function()
 			end
 		)
 
-		it(
-			"should fail when the received value is greater than the expected value",
-			function()
+		describe("should fail", function()
+			test(
+				"when the received value is greater than the expected value",
+				function()
+					-- Given
+					local greaterNumber = 10
+					local smallerNumber = 5
+
+					-- When
+					local result = matchers.toBeLessThan(
+						CONTEXT,
+						greaterNumber,
+						smallerNumber
+					)
+
+					-- Then
+					assertMatcher.failed(result)
+					assertMatcher.hasMessage(
+						result,
+						("Expected %d to be less than %d"):format(
+							greaterNumber,
+							smallerNumber
+						)
+					)
+				end
+			)
+
+			test("on NaN for any parameter", function()
 				-- Given
-				local greaterNumber = 10
-				local smallerNumber = 5
+				local normalNumber = 1
 
 				-- When
-				local result =
-					matchers.toBeLessThan(CONTEXT, greaterNumber, smallerNumber)
+				local result = matchers.toBeLessThan(CONTEXT, normalNumber, NAN)
+
+				local resultSwapped =
+					matchers.toBeLessThan(CONTEXT, NAN, normalNumber)
 
 				-- Then
 				assertMatcher.failed(result)
 				assertMatcher.hasMessage(
 					result,
-					("Expected %d to be less than %d"):format(
-						greaterNumber,
-						smallerNumber
+					("Expected %d to be less than %s"):format(
+						normalNumber,
+						tostring(NAN)
 					)
 				)
-			end
-		)
-
-		it("should fail on NaN for any parameter", function()
-			-- Given
-			local normalNumber = 1
-
-			-- When
-			local result = matchers.toBeLessThan(CONTEXT, normalNumber, NAN)
-
-			local resultSwapped =
-				matchers.toBeLessThan(CONTEXT, NAN, normalNumber)
-
-			-- Then
-			assertMatcher.failed(result)
-			assertMatcher.hasMessage(
-				result,
-				("Expected %d to be less than %s"):format(
-					normalNumber,
-					tostring(NAN)
+				assertMatcher.failed(resultSwapped)
+				assertMatcher.hasMessage(
+					resultSwapped,
+					("Expected %s to be less than %d"):format(
+						tostring(NAN),
+						normalNumber
+					)
 				)
-			)
-			assertMatcher.failed(resultSwapped)
-			assertMatcher.hasMessage(
-				resultSwapped,
-				("Expected %s to be less than %d"):format(
-					tostring(NAN),
-					normalNumber
-				)
-			)
+			end)
 		end)
 
 		it("should have an inverted message", function()
@@ -474,60 +487,62 @@ describe("number matchers", function()
 			end
 		)
 
-		it(
-			"should fail when the received value is greater than the expected value",
-			function()
+		describe("should fail", function()
+			test(
+				"when the received value is greater than the expected value",
+				function()
+					-- Given
+					local greaterNumber = 10
+					local smallerNumber = 3
+
+					-- When
+					local result = matchers.toBeLessThanOrEqual(
+						CONTEXT,
+						greaterNumber,
+						smallerNumber
+					)
+
+					-- Then
+					assertMatcher.failed(result)
+					assertMatcher.hasMessage(
+						result,
+						("Expected %d to be less than or equal to %d"):format(
+							greaterNumber,
+							smallerNumber
+						)
+					)
+				end
+			)
+
+			test("on NaN for any parameter", function()
 				-- Given
-				local greaterNumber = 10
-				local smallerNumber = 3
+				local normalNumber = 1
 
 				-- When
-				local result = matchers.toBeLessThanOrEqual(
-					CONTEXT,
-					greaterNumber,
-					smallerNumber
-				)
+				local result =
+					matchers.toBeLessThanOrEqual(CONTEXT, normalNumber, NAN)
+
+				local resultSwapped =
+					matchers.toBeLessThanOrEqual(CONTEXT, NAN, normalNumber)
 
 				-- Then
 				assertMatcher.failed(result)
 				assertMatcher.hasMessage(
 					result,
-					("Expected %d to be less than or equal to %d"):format(
-						greaterNumber,
-						smallerNumber
+					("Expected %d to be less than or equal to %s"):format(
+						normalNumber,
+						tostring(NAN)
 					)
 				)
-			end
-		)
-
-		it("should fail on NaN for any parameter", function()
-			-- Given
-			local normalNumber = 1
-
-			-- When
-			local result =
-				matchers.toBeLessThanOrEqual(CONTEXT, normalNumber, NAN)
-
-			local resultSwapped =
-				matchers.toBeLessThanOrEqual(CONTEXT, NAN, normalNumber)
-
-			-- Then
-			assertMatcher.failed(result)
-			assertMatcher.hasMessage(
-				result,
-				("Expected %d to be less than or equal to %s"):format(
-					normalNumber,
-					tostring(NAN)
+				assertMatcher.failed(resultSwapped)
+				assertMatcher.hasMessage(
+					resultSwapped,
+					("Expected %s to be less than or equal to %d"):format(
+						tostring(NAN),
+						normalNumber
+					)
 				)
-			)
-			assertMatcher.failed(resultSwapped)
-			assertMatcher.hasMessage(
-				resultSwapped,
-				("Expected %s to be less than or equal to %d"):format(
-					tostring(NAN),
-					normalNumber
-				)
-			)
+			end)
 		end)
 
 		it("should have an inverted message", function()


### PR DESCRIPTION
Summary:

- Added all of the scaffold for number matchers.
- Added a corresponding test suite for them.
- `toBeCloseTo`'s implementation is exactly the Jest implementation.