### PR TITLE
LEST-31 - Table matchers

### DIFF
--- a/src/matchers/tables.lua
+++ b/src/matchers/tables.lua
@@ -26,7 +26,7 @@ local function toContain(ctx, received, item)
 	local pass = false
 
 	if type(received) == "string" then
-		pass = received:find(tostring(item), 1, true) ~= nil
+		pass = type(item) == "string" and received:find(item, 1, true) ~= nil
 	elseif type(received) == "table" then
 		for _, value in pairs(received) do
 			if value == item then

--- a/src/matchers/tables.lua
+++ b/src/matchers/tables.lua
@@ -26,8 +26,7 @@ local function toContain(ctx, received, item)
 	local pass = false
 
 	if type(received) == "string" then
-		assertType(item, "string")
-		pass = received:find(item, 1, true) ~= nil
+		pass = received:find(tostring(item), 1, true) ~= nil
 	elseif type(received) == "table" then
 		for _, value in pairs(received) do
 			if value == item then
@@ -76,22 +75,6 @@ end
 local function toMatchObject(ctx, received, object)
 	assertType(object, "table")
 
-	local function createMatcherResult(passed)
-		return {
-			pass = passed,
-			message = string.format(
-				"Expected %s to%smatch %s",
-				prettyValue(received),
-				ctx.inverted and " not " or " ",
-				prettyValue(object)
-			),
-		}
-	end
-
-	if type(received) ~= "table" then
-		return createMatcherResult(false)
-	end
-
 	--- Internal recursive function to determine if any property of `a` matches with `b`.
 	---@param a table
 	---@param b table
@@ -119,7 +102,15 @@ local function toMatchObject(ctx, received, object)
 		return true
 	end
 
-	return createMatcherResult(matches(received, object))
+	return {
+		pass = type(received) == "table" and matches(received, object),
+		message = string.format(
+			"Expected %s to%smatch %s",
+			prettyValue(received),
+			ctx.inverted and " not " or " ",
+			prettyValue(object)
+		),
+	}
 end
 
 return {

--- a/src/matchers/tables.lua
+++ b/src/matchers/tables.lua
@@ -3,10 +3,8 @@ local deepEqual = require("src.utils.deepEqual")
 
 ---@type lest.Matcher
 local function toHaveLength(ctx, received, length)
-	local receivedLen = #received
-
 	return {
-		pass = receivedLen == length,
+		pass = #received == length,
 		message = string.format(
 			"Expected %s to%shave the length of %d",
 			prettyValue(received),

--- a/src/matchers/tables.lua
+++ b/src/matchers/tables.lua
@@ -22,6 +22,7 @@ local function toContain(ctx, received, item)
 	local pass = false
 
 	if type(received) == "string" then
+		assertType(item, "string")
 		pass = received:find(item) ~= nil
 	elseif type(received) == "table" then
 		for _, value in pairs(received) do
@@ -57,6 +58,7 @@ local function toContainEqual(ctx, received, item)
 			break
 		end
 	end
+
 	return {
 		pass = pass,
 		message = string.format(

--- a/src/matchers/tables.lua
+++ b/src/matchers/tables.lua
@@ -1,13 +1,80 @@
----@type lest.Matcher
-local function toHaveLength(ctx, received, length) end
+local prettyValue = require("src.utils.prettyValue")
+local deepEqual = require("src.utils.deepEqual")
 
 ---@type lest.Matcher
-local function toContain(ctx, received, item) end
+local function toHaveLength(ctx, received, length)
+	local receivedLen = #received
+
+	return {
+		pass = receivedLen == length,
+		message = string.format(
+			"Expected %s to%shave the length of %d",
+			prettyValue(received),
+			ctx.inverted and " not " or " ",
+			length
+		),
+	}
+end
 
 ---@type lest.Matcher
-local function toContainEqual(ctx, received, item) end
+local function toContain(ctx, received, item)
+	local pass = false
+
+	if type(received) == "string" then
+		pass = received:find(item) ~= nil
+	elseif type(received) == "table" then
+		for _, value in pairs(received) do
+			if value == item then
+				pass = true
+				break
+			end
+		end
+	else
+		error("Expected to receive a string or a table")
+	end
+
+	return {
+		pass = pass,
+		message = string.format(
+			"Expected %s to%scontain %s",
+			prettyValue(received),
+			ctx.inverted and " not " or " ",
+			prettyValue(item)
+		),
+	}
+end
+
+---@type lest.Matcher
+local function toContainEqual(ctx, received, item)
+	local pass = false
+
+	if type(received) == "table" then
+		for _, value in pairs(received) do
+			if deepEqual(value, item) then
+				pass = true
+				break
+			end
+		end
+	else
+		error("Expected to receive a table")
+	end
+
+	return {
+		pass = pass,
+		message = string.format(
+			"Expected %s to%scontain %s with deep equality",
+			prettyValue(received),
+			ctx.inverted and " not " or " ",
+			prettyValue(item)
+		),
+	}
+end
 
 ---@type lest.Matcher
 local function toMatchObject(ctx, received, object) end
 
-return {}
+return {
+	toHaveLength = toHaveLength,
+	toContain = toContain,
+	toContainEqual = toContainEqual,
+}

--- a/src/matchers/tables.lua
+++ b/src/matchers/tables.lua
@@ -1,8 +1,11 @@
 local prettyValue = require("src.utils.prettyValue")
 local deepEqual = require("src.utils.deepEqual")
+local assertType = require("src.asserts.type")
 
 ---@type lest.Matcher
 local function toHaveLength(ctx, received, length)
+	assertType(length, "number")
+
 	return {
 		pass = #received == length,
 		message = string.format(
@@ -44,19 +47,16 @@ end
 
 ---@type lest.Matcher
 local function toContainEqual(ctx, received, item)
+	assertType(received, "table")
+
 	local pass = false
 
-	if type(received) == "table" then
-		for _, value in pairs(received) do
-			if deepEqual(value, item) then
-				pass = true
-				break
-			end
+	for _, value in pairs(received) do
+		if deepEqual(value, item) then
+			pass = true
+			break
 		end
-	else
-		error("Expected to receive a table")
 	end
-
 	return {
 		pass = pass,
 		message = string.format(
@@ -69,10 +69,54 @@ local function toContainEqual(ctx, received, item)
 end
 
 ---@type lest.Matcher
-local function toMatchObject(ctx, received, object) end
+local function toMatchObject(ctx, received, object)
+	assertType(received, "table")
+	assertType(object, "table")
+
+	--- Internal recursive function to determine if any property of `a` matches with `b`.
+	---@param a table
+	---@param b table
+	local function _matches(a, b)
+		if #a ~= #b then
+			-- This is done because this usually means that .toMatchObject
+			-- was called with an array of objects. Jest's .toMatchObject enforces
+			-- that each array is the same length. However, if a and b are just dictionaries, this
+			-- condition will pass because the length operator does not count string keys.
+			return false
+		end
+
+		for aKey, aValue in pairs(a) do
+			local bValue = b[aKey]
+			if bValue then
+				if type(aValue) == "table" and type(bValue) == "table" then
+					if not _matches(aValue, bValue) then
+						return false
+					end
+				else
+					if aValue ~= bValue then
+						return false
+					end
+				end
+			end
+		end
+
+		return true
+	end
+
+	return {
+		pass = _matches(received, object),
+		message = string.format(
+			"Expected %s to%smatch %s",
+			prettyValue(received),
+			ctx.inverted and " not " or " ",
+			prettyValue(object)
+		),
+	}
+end
 
 return {
 	toHaveLength = toHaveLength,
 	toContain = toContain,
 	toContainEqual = toContainEqual,
+	toMatchObject = toMatchObject,
 }

--- a/src/matchers/tables.test.lua
+++ b/src/matchers/tables.test.lua
@@ -1,0 +1,238 @@
+local matchers = require("src.matchers.tables")
+local assertMatcher = require("src.asserts.matchers")
+local prettyValue = require("src.utils.prettyValue")
+
+describe("table matchers", function()
+	local CONTEXT = {
+		inverted = false,
+	}
+
+	local INVERTED_CONTEXT = {
+		inverted = true,
+	}
+
+	describe("toHaveLength", function()
+		it(
+			"should pass when the received object has the expected length",
+			function()
+				-- Given
+				local testArray = { 1, 2, 3 }
+				local testTable = { a = 1, b = 2, c = 3 }
+				local testString = "abcde"
+
+				-- When
+				local resultArray = matchers.toHaveLength(CONTEXT, testArray, 3)
+				local resultTable = matchers.toHaveLength(CONTEXT, testTable, 0)
+				local resultString =
+					matchers.toHaveLength(CONTEXT, testString, 5)
+
+				-- Then
+				assertMatcher.passed(resultArray)
+				assertMatcher.passed(resultTable)
+				assertMatcher.passed(resultString)
+			end
+		)
+
+		it(
+			"should fail when the received object doesn't has the expected length",
+			function()
+				-- Given
+				local testArray = { 2, 3, 4 }
+
+				-- When
+				local resultArray = matchers.toHaveLength(CONTEXT, testArray, 4)
+
+				-- Then
+				assertMatcher.failed(resultArray)
+				assertMatcher.hasMessage(
+					resultArray,
+					("Expected %s to have the length of %d"):format(
+						prettyValue(testArray),
+						4
+					)
+				)
+			end
+		)
+
+		it("should have an inverted message", function()
+			-- Given
+			local testArray = { 2, 3, 4 }
+
+			-- When
+			local resultArray =
+				matchers.toHaveLength(INVERTED_CONTEXT, testArray, 4)
+
+			-- Then
+			assertMatcher.hasMessage(
+				resultArray,
+				("Expected %s to not have the length of %d"):format(
+					prettyValue(testArray),
+					4
+				)
+			)
+		end)
+	end)
+
+	describe("toContain", function()
+		describe("should pass", function()
+			test(
+				"when the received object contains the expected item",
+				function()
+					-- Given
+					local testArray = { 1, 2, "foo" }
+					local testItem = "foo"
+
+					-- When
+					local result =
+						matchers.toContain(CONTEXT, testArray, testItem)
+
+					-- Then
+					assertMatcher.passed(result)
+				end
+			)
+
+			test(
+				"when the received object is a string and it contains the expected substring",
+				function()
+					-- Given
+					local testString = "foobar"
+					local testItem = "foo"
+
+					-- When
+					local result =
+						matchers.toContain(CONTEXT, testString, testItem)
+
+					-- Then
+					assertMatcher.passed(result)
+				end
+			)
+		end)
+
+		describe("should fail", function()
+			test(
+				"when the received object doesn't contain the expected item",
+				function()
+					-- Given
+					local testArray = { 1, 2, "foo" }
+					local testItem = "quux"
+
+					-- When
+					local result =
+						matchers.toContain(CONTEXT, testArray, testItem)
+
+					-- Then
+					assertMatcher.failed(result)
+					assertMatcher.hasMessage(
+						result,
+						("Expected %s to contain %s"):format(
+							prettyValue(testArray),
+							prettyValue(testItem)
+						)
+					)
+				end
+			)
+
+			test(
+				"when the received object is a string and it doesn't contains the expected substring",
+				function()
+					-- Given
+					local testString = "foobar"
+					local testItem = "quux"
+
+					-- When
+					local result =
+						matchers.toContain(CONTEXT, testString, testItem)
+
+					-- Then
+					assertMatcher.failed(result)
+					assertMatcher.hasMessage(
+						result,
+						("Expected %s to contain %s"):format(
+							prettyValue(testString),
+							prettyValue(testItem)
+						)
+					)
+				end
+			)
+		end)
+
+		it("should have an inverted message", function()
+			-- Given
+			local testArray = { 1, 10 }
+			local testItem = 10
+
+			-- When
+			local result =
+				matchers.toContain(INVERTED_CONTEXT, testArray, testItem)
+
+			-- Given
+			assertMatcher.hasMessage(
+				result,
+				("Expected %s to not contain %s"):format(
+					prettyValue(testArray),
+					prettyValue(testItem)
+				)
+			)
+		end)
+	end)
+
+	describe("toContainEqual", function()
+		it(
+			"should pass when the received object contains the expected item with deep equality",
+			function()
+				-- Given
+				local testArray = { 1, { hello = 10, hi = { turn = 10 } }, 2 }
+				local testItem = { hello = 10, hi = { turn = 10 } }
+
+				-- When
+				local result =
+					matchers.toContainEqual(CONTEXT, testArray, testItem)
+
+				-- Then
+				assertMatcher.passed(result)
+			end
+		)
+
+		it(
+			"should fail when the received object doesn't contains the expected item with deep equality",
+			function()
+				-- Given
+				local testArray = { 1, { hello = 10, hi = { turn = 10 } }, 2 }
+				local testItem = { foo = 10, bar = { quux = 10 } }
+
+				-- When
+				local result =
+					matchers.toContainEqual(CONTEXT, testArray, testItem)
+
+				-- Then
+				assertMatcher.failed(result)
+				assertMatcher.hasMessage(
+					result,
+					("Expected %s to contain %s with deep equality"):format(
+						prettyValue(testArray),
+						prettyValue(testItem)
+					)
+				)
+			end
+		)
+
+		it("should have an inverted message", function()
+			-- Given
+			local testArray = { 1, 30, 10 }
+			local testItem = 30
+
+			-- When
+			local result =
+				matchers.toContainEqual(INVERTED_CONTEXT, testArray, testItem)
+
+			-- Then
+			assertMatcher.hasMessage(
+				result,
+				("Expected %s to not contain %s with deep equality"):format(
+					prettyValue(testArray),
+					prettyValue(testItem)
+				)
+			)
+		end)
+	end)
+end)

--- a/src/matchers/tables.test.lua
+++ b/src/matchers/tables.test.lua
@@ -176,7 +176,7 @@ describe("table matchers", function()
 			)
 
 			test(
-				"when the received object is neither a string or a table",
+				"when the received object is neither a string nor a table",
 				function()
 					-- Given
 					local invalidObject = 10
@@ -237,7 +237,7 @@ describe("table matchers", function()
 
 		describe("should fail", function()
 			test(
-				"when the received object doesn't contains the expected item with deep equality",
+				"when the received object doesn't contain the expected item with deep equality",
 				function()
 					-- Given
 					local testArray =
@@ -449,7 +449,7 @@ describe("table matchers", function()
 				end
 			)
 
-			test("when the received object is not a table", function()
+			test("when the received value is not a table", function()
 				-- Given
 				local invalidObject = "hello"
 				local matchTable = { e = 10 }

--- a/src/matchers/tables.test.lua
+++ b/src/matchers/tables.test.lua
@@ -235,4 +235,184 @@ describe("table matchers", function()
 			)
 		end)
 	end)
+
+	describe("toMatchObject", function()
+		describe("should pass", function()
+			test(
+				"when the received object matches the expected object",
+				function()
+					-- Given
+					local testObject = {
+						a = 10,
+						b = "eleven",
+						c = "quux",
+					}
+
+					local testMatchObject = {
+						a = 10,
+						b = "eleven",
+					}
+
+					-- When
+					local result = matchers.toMatchObject(
+						CONTEXT,
+						testObject,
+						testMatchObject
+					)
+
+					-- Then
+					assertMatcher.passed(result)
+				end
+			)
+
+			test(
+				"when the received array of objects matches the expected array of objects",
+				function()
+					-- Given
+					local testObjectArray = {
+						{
+							a = 10,
+							b = "eleven",
+							c = "quux",
+						},
+
+						{
+							foo = 85,
+							bar = "lest",
+						},
+					}
+
+					local testMatchObjectArray = {
+						{
+							a = 10,
+							b = "eleven",
+						},
+
+						{ bar = "lest" },
+					}
+
+					-- When
+					local result = matchers.toMatchObject(
+						CONTEXT,
+						testObjectArray,
+						testMatchObjectArray
+					)
+
+					-- Then
+					assertMatcher.passed(result)
+				end
+			)
+		end)
+
+		describe("should fail", function()
+			test(
+				"when the received object doesn't matches the expected object",
+				function()
+					-- Given
+					local testObject = {
+						a = 10,
+						b = "eleven",
+						c = "quux",
+					}
+
+					local testMatchObject = {
+						a = 17,
+						b = "twelve",
+					}
+
+					-- When
+					local result = matchers.toMatchObject(
+						CONTEXT,
+						testObject,
+						testMatchObject
+					)
+
+					-- Then
+					assertMatcher.failed(result)
+					assertMatcher.hasMessage(
+						result,
+						("Expected %s to match %s"):format(
+							prettyValue(testObject),
+							prettyValue(testMatchObject)
+						)
+					)
+				end
+			)
+
+			test(
+				"when the received array of objects doesn't match the expected array of objects",
+				function()
+					-- Given
+					local testObjectArray = {
+						{
+							a = 10,
+							b = "eleven",
+							c = "quux",
+						},
+
+						{
+							foo = 85,
+							bar = "lest",
+						},
+					}
+
+					local testMatchObjectArray = {
+						{
+							a = 10,
+							b = "eleven",
+						},
+
+						{ bar = "lest" },
+
+						{ quux = "fiddle" },
+					}
+
+					-- When
+					local result = matchers.toMatchObject(
+						CONTEXT,
+						testObjectArray,
+						testMatchObjectArray
+					)
+
+					-- Then
+					assertMatcher.failed(result)
+					assertMatcher.hasMessage(
+						result,
+						("Expected %s to match %s"):format(
+							prettyValue(testObjectArray),
+							prettyValue(testMatchObjectArray)
+						)
+					)
+				end
+			)
+		end)
+
+		it("should have an inverted message", function()
+			-- Given
+			local testObject = {
+				a = 1,
+				finger = "appendage",
+			}
+
+			local testMatchObject = {
+				a = 1,
+			}
+
+			-- When
+			local result = matchers.toMatchObject(
+				INVERTED_CONTEXT,
+				testObject,
+				testMatchObject
+			)
+
+			-- Then
+			assertMatcher.hasMessage(
+				result,
+				("Expected %s to not match %s"):format(
+					prettyValue(testObject),
+					prettyValue(testMatchObject)
+				)
+			)
+		end)
+	end)
 end)

--- a/src/matchers/tables.test.lua
+++ b/src/matchers/tables.test.lua
@@ -33,26 +33,47 @@ describe("table matchers", function()
 			end
 		)
 
-		it(
-			"should fail when the received object doesn't has the expected length",
-			function()
+		describe("should fail", function()
+			test(
+				"when the received object doesn't has the expected length",
+				function()
+					-- Given
+					local testArray = { 2, 3, 4 }
+
+					-- When
+					local resultArray =
+						matchers.toHaveLength(CONTEXT, testArray, 4)
+
+					-- Then
+					assertMatcher.failed(resultArray)
+					assertMatcher.hasMessage(
+						resultArray,
+						("Expected %s to have a length of %d"):format(
+							prettyValue(testArray),
+							4
+						)
+					)
+				end
+			)
+
+			test("when the received object has no length", function()
 				-- Given
-				local testArray = { 2, 3, 4 }
+				local noLengthObject = 1
 
 				-- When
-				local resultArray = matchers.toHaveLength(CONTEXT, testArray, 4)
+				local result =
+					matchers.toHaveLength(CONTEXT, noLengthObject, 10)
 
 				-- Then
-				assertMatcher.failed(resultArray)
+				assertMatcher.failed(result)
 				assertMatcher.hasMessage(
-					resultArray,
-					("Expected %s to have the length of %d"):format(
-						prettyValue(testArray),
-						4
+					result,
+					("Expected %s to have a length of 10"):format(
+						prettyValue(noLengthObject)
 					)
 				)
-			end
-		)
+			end)
+		end)
 
 		it("should have an inverted message", function()
 			-- Given
@@ -65,9 +86,8 @@ describe("table matchers", function()
 			-- Then
 			assertMatcher.hasMessage(
 				resultArray,
-				("Expected %s to not have the length of %d"):format(
-					prettyValue(testArray),
-					4
+				("Expected %s to not have a length of 4"):format(
+					prettyValue(testArray)
 				)
 			)
 		end)
@@ -154,6 +174,28 @@ describe("table matchers", function()
 					)
 				end
 			)
+
+			test(
+				"when the received object is neither a string or a table",
+				function()
+					-- Given
+					local invalidObject = 10
+
+					-- When
+					local result =
+						matchers.toContain(CONTEXT, invalidObject, 10)
+
+					-- Then
+					assertMatcher.failed(result)
+					assertMatcher.hasMessage(
+						result,
+						("Expected %s to contain %s"):format(
+							prettyValue(invalidObject),
+							prettyValue(10)
+						)
+					)
+				end
+			)
 		end)
 
 		it("should have an inverted message", function()
@@ -193,28 +235,49 @@ describe("table matchers", function()
 			end
 		)
 
-		it(
-			"should fail when the received object doesn't contains the expected item with deep equality",
-			function()
+		describe("should fail", function()
+			test(
+				"when the received object doesn't contains the expected item with deep equality",
+				function()
+					-- Given
+					local testArray =
+						{ 1, { hello = 10, hi = { turn = 10 } }, 2 }
+					local testItem = { foo = 10, bar = { quux = 10 } }
+
+					-- When
+					local result =
+						matchers.toContainEqual(CONTEXT, testArray, testItem)
+
+					-- Then
+					assertMatcher.failed(result)
+					assertMatcher.hasMessage(
+						result,
+						("Expected %s to contain %s with deep equality"):format(
+							prettyValue(testArray),
+							prettyValue(testItem)
+						)
+					)
+				end
+			)
+
+			test("when the received object is not a table", function()
 				-- Given
-				local testArray = { 1, { hello = 10, hi = { turn = 10 } }, 2 }
-				local testItem = { foo = 10, bar = { quux = 10 } }
+				local invalidObject = 45
 
 				-- When
 				local result =
-					matchers.toContainEqual(CONTEXT, testArray, testItem)
+					matchers.toContainEqual(CONTEXT, invalidObject, 45)
 
 				-- Then
 				assertMatcher.failed(result)
 				assertMatcher.hasMessage(
 					result,
-					("Expected %s to contain %s with deep equality"):format(
-						prettyValue(testArray),
-						prettyValue(testItem)
+					("Expected %s to contain 45 with deep equality"):format(
+						prettyValue(invalidObject)
 					)
 				)
-			end
-		)
+			end)
+		end)
 
 		it("should have an inverted message", function()
 			-- Given
@@ -306,7 +369,7 @@ describe("table matchers", function()
 
 		describe("should fail", function()
 			test(
-				"when the received object doesn't matches the expected object",
+				"when the received object doesn't match the expected object",
 				function()
 					-- Given
 					local testObject = {
@@ -385,6 +448,26 @@ describe("table matchers", function()
 					)
 				end
 			)
+
+			test("when the received object is not a table", function()
+				-- Given
+				local invalidObject = "hello"
+				local matchTable = { e = 10 }
+
+				-- When
+				local result =
+					matchers.toMatchObject(CONTEXT, invalidObject, matchTable)
+
+				-- Then
+				assertMatcher.failed(result)
+				assertMatcher.hasMessage(
+					result,
+					("Expected %s to match %s"):format(
+						prettyValue(invalidObject),
+						prettyValue(matchTable)
+					)
+				)
+			end)
 		end)
 
 		it("should have an inverted message", function()


### PR DESCRIPTION
Summary:

- Implements the scaffold table matchers.
- Adds a table matcher test suite.

All of these matchers were based upon Jest (tested and from the docs) because they primarily operate on JavaScript arrays and objects which are differentiated from each other unlike Lua.