### PR TITLE
LEST-57 - Allow mocking dofile and loadfile

### DIFF
--- a/src/mocking/functions.lua
+++ b/src/mocking/functions.lua
@@ -1,6 +1,9 @@
 local tablex = require("src.utils.tablex")
 local assertType = require("src.asserts.type")
 
+---@diagnostic disable-next-line: deprecated
+local unpack = table.unpack or unpack
+
 lest = lest or {}
 
 lest._realType = lest._realType or type
@@ -12,9 +15,6 @@ function _G.type(v)
 
 	return lest._realType(v)
 end
-
----@diagnostic disable-next-line: deprecated
-local unpack = table.unpack or unpack
 
 ---@class lest.Mock : function
 ---@field mock { calls: any[][], lastCall?: any[], results: lest.MockResult[], lastResult?: lest.MockResult }

--- a/src/mocking/modules.lua
+++ b/src/mocking/modules.lua
@@ -3,18 +3,26 @@ local assertType = require("src.asserts.type")
 
 lest = lest or {}
 
----@type table<string, function>
+---@type table<string, table<string, function>>
 local moduleMocks = {}
 
-lest.requireActual = lest.requireActual or require
+local function registerImporterMock(importerName)
+	moduleMocks[importerName] = {}
 
-function _G.require(moduleName)
-	if moduleMocks[moduleName] then
-		return moduleMocks[moduleName]()
+	local actualFunctionName = importerName .. "Actual"
+	lest[actualFunctionName] = lest[actualFunctionName] or _G[importerName]
+
+	_G[importerName] = function(moduleName)
+		local moduleFactory = moduleMocks[importerName][moduleName]
+		if moduleFactory then
+			return moduleFactory()
+		end
+
+		return lest[actualFunctionName](moduleName)
 	end
-
-	return lest.requireActual(moduleName)
 end
+
+registerImporterMock("require")
 
 local mockTable
 local function mockValue(val, path)
@@ -48,34 +56,22 @@ end
 --- If importing the given module triggers any side effects, you may need to manually mock it with the factory function.
 ---@param moduleName string
 ---@param factory? function
----@param options? { virtual: boolean }
-function lest.mock(moduleName, factory, options)
-	options = options or {}
-
+function lest.mock(moduleName, factory)
 	assertType(moduleName, "string", "moduleName", 2)
 	if factory then
 		assertType(factory, "function", "factory", 2)
 	end
-	assertType(options, "table", "options", 2)
 
 	if factory then
-		-- Asserts the module exists
-		if not options.virtual then
-			lest.requireActual(moduleName)
-		end
-
-		moduleMocks[moduleName] = function()
-			return factory()
+		moduleMocks.require[moduleName] = function()
+			local firstRetval = factory()
+			return firstRetval
 		end
 	else
-		if options.virtual then
-			error(Error("A factory must be used to mock a virtual module"))
-		end
-
 		-- We cache the mocked module as require also caches
 		local mockedModule =
 			mockValue(lest.requireActual(moduleName), moduleName)
-		moduleMocks[moduleName] = function()
+		moduleMocks.require[moduleName] = function()
 			return mockedModule
 		end
 	end
@@ -88,19 +84,19 @@ end
 function lest.removeModuleMock(moduleName)
 	assertType(moduleName, "string", "moduleName", 2)
 
-	if not moduleMocks[moduleName] then
+	if not moduleMocks.require[moduleName] then
 		error(
 			Error(string.format("Module '%s' has not been mocked", moduleName)),
 			2
 		)
 	end
 
-	moduleMocks[moduleName] = nil
+	moduleMocks.require[moduleName] = nil
 end
 
 --- Removes the mock for all mocked modules.
 ---
 --- There is no equivalent to this in Jest. Not to be confused with `lest.unmock`.
 function lest.removeAllModuleMocks()
-	moduleMocks = {}
+	moduleMocks.require = {}
 end

--- a/tests/moduleMocking.test.lua
+++ b/tests/moduleMocking.test.lua
@@ -37,26 +37,13 @@ describe("lest.mock", function()
 		end
 	)
 
-	it(
-		"should throw an error when a factory is passed and the module does not exist",
-		function()
-			-- Given
-			local mockModuleFn = function()
-				lest.mock(invalidModuleName, function() end)
-			end
-
-			-- Then
-			expect(mockModuleFn).toThrow("module 'this.is.not.real' not found")
-		end
-	)
-
 	it("should mock a virtual module when a factory is passed", function()
 		-- Given
 		local virtualModulePath = "not a real module" -- Can't use invalidModuleName as it will affect later tests
 		local mockFactoryFn = lest.fn()
 
 		-- When
-		lest.mock(virtualModulePath, mockFactoryFn, { virtual = true })
+		lest.mock(virtualModulePath, mockFactoryFn)
 		require(virtualModulePath)
 
 		-- Then
@@ -114,18 +101,6 @@ describe("lest.mock", function()
 		expect(foo).toThrow("Module was not mocked")
 	end)
 
-	it("should throw an error when auto mocking a virtual module", function()
-		-- Given
-		local mockModuleFn = function()
-			lest.mock(moduleName, nil, { virtual = true })
-		end
-
-		-- Then
-		expect(mockModuleFn).toThrow(
-			"A factory must be used to mock a virtual module"
-		)
-	end)
-
 	describe("argument assertions", function()
 		it("should throw when the module name is not a string", function()
 			-- Given
@@ -155,19 +130,6 @@ describe("lest.mock", function()
 				)
 			end
 		)
-
-		it("should throw when options are given and not a table", function()
-			-- Given
-			local mockModuleFn = function()
-				---@diagnostic disable-next-line: param-type-mismatch
-				lest.mock("", nil, 1234)
-			end
-
-			-- Then
-			expect(mockModuleFn).toThrow(
-				"TypeError: Expected options to be a table"
-			)
-		end)
 	end)
 end)
 

--- a/tests/moduleMocking.test.lua
+++ b/tests/moduleMocking.test.lua
@@ -5,18 +5,23 @@ local invalidModuleName = "this.is.not.real"
 local testCases = {
 	{
 		importerName = "require",
+		importer = require,
 		moduleName = "tests.data.moduleToMock",
 		secondModuleName = "tests.data.moduleToMock2",
 		invalidModuleName = "this.is.not.real",
 	},
 	{
 		importerName = "loadfile",
+		importer = function(moduleName)
+			return loadfile(moduleName)()
+		end,
 		moduleName = "tests/data/moduleToMock.lua",
 		secondModuleName = "tests/data/moduleToMock2.lua",
 		invalidModuleName = "this/is/not/real.lua",
 	},
 	{
 		importerName = "dofile",
+		importer = dofile,
 		moduleName = "tests/data/moduleToMock.lua",
 		secondModuleName = "tests/data/moduleToMock2.lua",
 		invalidModuleName = "this/is/not/real.lua",
@@ -27,12 +32,7 @@ describe("lest.mock", function()
 	-- TODO LEST-61: Replace loop with describe.each
 	for _, testCase in ipairs(testCases) do
 		describe("with " .. testCase.importerName, function()
-			local importer = testCase.importerName == "loadfile"
-					and function(moduleName)
-						return loadfile(moduleName)()
-					end
-				or _G[testCase.importerName]
-
+			local importer = testCase.importer
 			local importerActual = testCase.importerName == "loadfile"
 					and function(moduleName)
 						return lest.loadfileActual(moduleName)()
@@ -188,12 +188,7 @@ describe("lest.removeModuleMock", function()
 	-- TODO LEST-61: Replace loop with describe.each
 	for _, testCase in ipairs(testCases) do
 		describe("with " .. testCase.importerName, function()
-			local importer = testCase.importerName == "loadfile"
-					and function(moduleName)
-						return loadfile(moduleName)()
-					end
-				or _G[testCase.importerName]
-
+			local importer = testCase.importer
 			local moduleName = testCase.moduleName
 
 			it("should remove the module mock", function()

--- a/tests/moduleMocking.test.lua
+++ b/tests/moduleMocking.test.lua
@@ -60,19 +60,6 @@ describe("lest.mock", function()
 			end)
 
 			it(
-				"should throw an error when no factory is passed and the module does not exist",
-				function()
-					-- Given
-					local mockModuleFn = function()
-						lest.mock(invalidModuleName)
-					end
-
-					-- Then
-					expect(mockModuleFn).toThrow("module '.+' not found")
-				end
-			)
-
-			it(
 				"should mock a virtual module when a factory is passed",
 				function()
 					-- Given


### PR DESCRIPTION
Adds a semi-flexible method of mocking out all module importing functions with a single `lest.mock` call.

Designed in such a way that registering other import functions could be exposed to the user at some point to support code written for non-standard Lua environments.