### PR TITLE
LEST-61 - Add describe.each and test.each

### DIFF
--- a/src/mocking/functions.lua
+++ b/src/mocking/functions.lua
@@ -1,8 +1,6 @@
 local tablex = require("src.utils.tablex")
 local assertType = require("src.asserts.type")
-
----@diagnostic disable-next-line: deprecated
-local unpack = table.unpack or unpack
+local unpack = require("src.utils.unpack")
 
 lest = lest or {}
 

--- a/src/mocking/modules.lua
+++ b/src/mocking/modules.lua
@@ -1,8 +1,6 @@
 local Error = require("src.errors.error")
 local assertType = require("src.asserts.type")
-
----@diagnostic disable-next-line: deprecated
-local unpack = table.unpack or unpack
+local unpack = require("src.utils.unpack")
 
 lest = lest or {}
 

--- a/src/utils/unpack.lua
+++ b/src/utils/unpack.lua
@@ -1,0 +1,2 @@
+---@diagnostic disable-next-line: deprecated
+return table.unpack or unpack

--- a/tests/moduleMocking.test.lua
+++ b/tests/moduleMocking.test.lua
@@ -22,9 +22,9 @@ local testCases = {
 }
 
 describe("lest.mock", function()
-	-- TODO LEST-61: Replace loop with describe.each
-	for _, importerName in ipairs({ "require", "loadfile", "dofile" }) do
-		describe("with " .. importerName, function()
+	describe.each({ "require", "loadfile", "dofile" })(
+		"with %s",
+		function(importerName)
 			local testCase = testCases[importerName]
 
 			local importer = testCase.importer
@@ -118,8 +118,8 @@ describe("lest.mock", function()
 					expect(foo).toThrow("Module was not mocked")
 				end
 			)
-		end)
-	end
+		end
+	)
 
 	it("should cache the auto mocked module when using require", function()
 		-- Given
@@ -194,9 +194,9 @@ describe("lest.mock", function()
 end)
 
 describe("lest.removeModuleMock", function()
-	-- TODO LEST-61: Replace loop with describe.each
-	for _, importerName in ipairs({ "require", "loadfile", "dofile" }) do
-		describe("with " .. importerName, function()
+	describe.each({ "require", "loadfile", "dofile" })(
+		"with %s",
+		function(importerName)
 			local testCase = testCases[importerName]
 
 			local importer = testCase.importer
@@ -213,8 +213,8 @@ describe("lest.removeModuleMock", function()
 				-- Then
 				expect(foo).toThrow("Module was not mocked")
 			end)
-		end)
-	end
+		end
+	)
 
 	it("should throw an error if the module has not been mocked", function()
 		-- Given


### PR DESCRIPTION
Adds the data driven testing functions from Jest with an almost equivalent feature set. Jest has far more complex string interpolation functionality for naming which we don't have.