### PR TITLE
LEST-66 - Add stack tracebacks to standard Lua errors thrown from tests

### DIFF
--- a/src/prettyprint.lua
+++ b/src/prettyprint.lua
@@ -139,7 +139,7 @@ local function printTestErrors(results, breadcrumbs)
 					)
 				)
 
-				printIndentedBlock(prettyValue(testOrDescribe.error))
+				printIndentedBlock(tostring(testOrDescribe.error))
 				print()
 			end
 		end

--- a/src/utils/timeout.lua
+++ b/src/utils/timeout.lua
@@ -9,6 +9,7 @@ local unpack = table.unpack or unpack
 local function withTimeout(timeout, func, ...)
 	local startTime = os.clock()
 	local timedOut = false
+	local args = { ... }
 
 	local oldSetTimeout = lest.setTimeout
 	function lest.setTimeout(newTimeout)
@@ -19,7 +20,7 @@ local function withTimeout(timeout, func, ...)
 	end
 
 	local results = {
-		xpcall(function(...)
+		xpcall(function()
 			hook.setCountHook(function()
 				if not timedOut and os.clock() - startTime > timeout then
 					timedOut = true
@@ -27,8 +28,8 @@ local function withTimeout(timeout, func, ...)
 				end
 			end)
 
-			return func(...)
-		end, debug.traceback, ...),
+			return func(unpack(args))
+		end, debug.traceback),
 	}
 
 	hook.setCountHook()

--- a/src/utils/timeout.lua
+++ b/src/utils/timeout.lua
@@ -19,7 +19,7 @@ local function withTimeout(timeout, func, ...)
 	end
 
 	local results = {
-		pcall(function(...)
+		xpcall(function(...)
 			hook.setCountHook(function()
 				if not timedOut and os.clock() - startTime > timeout then
 					timedOut = true
@@ -28,7 +28,7 @@ local function withTimeout(timeout, func, ...)
 			end)
 
 			return func(...)
-		end, ...),
+		end, debug.traceback, ...),
 	}
 
 	hook.setCountHook()

--- a/src/utils/timeout.lua
+++ b/src/utils/timeout.lua
@@ -1,10 +1,8 @@
 local hook = require("src.utils.hook")
 local TimeoutError = require("src.errors.timeout")
+local unpack = require("src.utils.unpack")
 
 lest = lest or {}
-
----@diagnostic disable-next-line: deprecated
-local unpack = table.unpack or unpack
 
 local function withTimeout(timeout, func, ...)
 	local startTime = os.clock()


### PR DESCRIPTION
Fixes normal errors thrown from tests not having a stack traceback

### Impact

Changes error printing in the pretty print library to use `tostring` instead of `prettyValue` to avoid wrapping tracebacks in quotes. This should have no real affect given string errors will always be decorated by `debug.traceback`.