### PR TITLE
LEST-NONE - Fix lest executable opening as a JS file

### DIFF
--- a/packages/lest/src/index.ts
+++ b/packages/lest/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import minimist from "minimist";
 import path from "path";
 import { findLuaExecutable } from "./helpers";


### PR DESCRIPTION
<!--
PR pre-flight checks:
- Have you updated any relevant documentation?
- Have you used appropriate conventional commit names, and have you tagged breaking changes?
  - https://cheatography.com/albelop/cheat-sheets/conventional-commits/
- Have you done a brief self-review of your changes to check if you've missed anything?
- If working on a ticket with defined scope and/or acceptance criteria, have you checked that you've hit everything?
  - If you intentionally haven't followed the ticket's requirements, please describe which requirements haven't been hit and why
-->

## Changes

<!-- Give a brief description of what you've changed -->
Previously, the lest executable would just open the actual JS file. Now, the lest executable actually runs!

## Impact

Developers can now `npm i @taservers/lest -D` and run it via `npx lest` or other methods.

## Testing

1. Create a new project. (`npm init -y`)
2. Install lest. (`npm i @taservers/lest -D`)
3. Run lest. (`npx lest`)

## Helpful Links

[API Docs](https://taservers.github.io/lest/docs/api/expect)

[Project Board](https://taservers.atlassian.net/jira/software/c/projects/LEST/boards/4)

[Discord](https://discord.tasevers.com)
