### PR TITLE
LEST-NONE - Make `packages/docs` a ES module.

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@lest/docs",
+  "type": "module",
   "private": true,
   "description": "API documentation in JSON form."
 }


### PR DESCRIPTION
<!--
PR pre-flight checks:
- Have you updated any relevant documentation?
- Have you used appropriate conventional commit names, and have you tagged breaking changes?
  - https://cheatography.com/albelop/cheat-sheets/conventional-commits/
- Have you done a brief self-review of your changes to check if you've missed anything?
- If working on a ticket with defined scope and/or acceptance criteria, have you checked that you've hit everything?
  - If you intentionally haven't followed the ticket's requirements, please describe which requirements haven't been hit and why
-->


## Changes

Added `type: "module"` to packages/docs/package.json.
This is required so certain ESM packages (like luals-annotations) can properly import it. The docs have javascript which uses ESM but has no marker, so Node gets confused and spews abominable errors.

## Impact

Anyone importing the index.js files from the docs will now be able to if they're using ESM. They'll also get a correct error if they're using CJS.

## Helpful Links

[API Docs](https://taservers.github.io/lest/docs/api/expect)

[Project Board](https://taservers.atlassian.net/jira/software/c/projects/LEST/boards/4)

[Discord](https://discord.tasevers.com)
