### PR TITLE
Make readme image URL absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-	<img alt="Lest, painless Lua testing" src="readme.png" width="70%" />
+	<img alt="Lest, painless Lua testing" src="https://raw.githubusercontent.com/TAServers/lest/master/readme.png" width="70%" />
 </h1>
 <p align="center">
 	<a href="https://www.npmjs.com/package/@taservers/lest" style="text-decoration: none;">

--- a/package-lock.json
+++ b/package-lock.json
@@ -18232,7 +18232,7 @@
     },
     "packages/lest": {
       "name": "@taservers/lest",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "lookpath": "^1.2.2",

--- a/packages/lest/CHANGELOG.md
+++ b/packages/lest/CHANGELOG.md
@@ -14,6 +14,12 @@ The valid change types are:
 -   `Fixed` for any bug fixes.
 -   `Security` in case of vulnerabilities.
 
+## [3.1.1] - [#TODO](https://github.com/TAServers/lest/pull/TODO
+
+### Fixed
+
+-   Fixed banner image URL in `README.md`
+
 ## [3.1.0] - [#113](https://github.com/TAServers/lest/pull/113)
 
 ### Added

--- a/packages/lest/package.json
+++ b/packages/lest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@taservers/lest",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "license": "MIT",
   "description": "Painless Lua testing.",
   "homepage": "https://taservers.github.io/lest/",


### PR DESCRIPTION
<!--
PR pre-flight checks:
- If modifying Lest:
  - Have you updated the package version in `package.json`?
  - Have you run `npm install` to update `package-lock.json`?
  - Have you added a matching changelog entry in `packages/lest/CHANGELOG.md`?
- Have you updated any relevant documentation?
- Have you done a brief self-review of your changes to check if you've missed anything?
- If working on an issue with defined scope and/or acceptance criteria, have you checked that you've hit everything?
  - If you intentionally haven't followed the issue's requirements, please describe which requirements haven't been hit and why
-->

## Issue

No issue number. Caused by #116 

## Changes

Uses an absolute URL for the readme banner image

## Impact

Fixes the banner image not displaying on NPM

## Testing

n/a

## Helpful Links

[API Docs](https://taservers.github.io/lest/docs/api/expect)

[Project Board](https://github.com/orgs/TAServers/projects/1)

[Discord](https://discord.tasevers.com)
